### PR TITLE
513 rich text formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ lib/
 locale-data/
 node_modules/
 src/en.js
+
+# IntelliJ
+.idea/

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -11,6 +11,7 @@ import {
     shallowEquals,
     shouldIntlComponentUpdate,
 } from '../utils';
+import {replacePlaceholders} from '../placeholders';
 
 export default class FormattedMessage extends Component {
     static displayName = 'FormattedMessage';
@@ -122,7 +123,7 @@ export default class FormattedMessage extends Component {
                 .filter((part) => !!part)
                 .map((part) => elements[part] || part);
         } else {
-            nodes = [formattedMessage];
+            nodes = replacePlaceholders(formattedMessage, values);
         }
 
         if (typeof children === 'function') {

--- a/src/placeholders.js
+++ b/src/placeholders.js
@@ -22,7 +22,7 @@ const addFragment = (fragments, fragment) => {
  */
 const extract = (translation) => {
     const placeholder = '[A-Za-z0-9_]+';
-    const re = new RegExp(`<x:(${placeholder})>(.*?)</x:\\1>`, 'g');
+    const re = new RegExp(`<x:(${placeholder})>([\\s\\S]*?)</x:\\1>`, 'g');
     let fragments = [];
     let startIndex = 0;
 

--- a/src/placeholders.js
+++ b/src/placeholders.js
@@ -1,0 +1,73 @@
+const createTextFragment = (text) => ({ text });
+
+const createPlaceholder = (name, content) => ({ name, content });
+
+const isPlaceholder = (fragment) => (!!fragment.name);
+
+const addFragment = (fragments, fragment) => {
+    if (!isPlaceholder(fragment) && !fragment.text) {
+        return fragments;
+    }
+
+    return fragments.concat(fragment);
+};
+
+/*
+ * This method looks for '<x:tag>...</x:tag>'
+ * Eg: My beautiful sentence with <x:link>a link</x:link>
+ *
+ * Note:
+ * - self-closing tags are not supported
+ * - nested tags with the same name are not supported
+ */
+const extract = (translation) => {
+    const placeholder = '[A-Za-z0-9_]+';
+    const re = new RegExp(`<x:(${placeholder})>(.*?)</x:\\1>`, 'g');
+    let fragments = [];
+    let startIndex = 0;
+
+    let match;
+    while ((match = re.exec(translation)) !== null) {
+        const [fullMatch, tagName, content] = match;
+        const matchingIndex = match.index;
+
+        fragments = addFragment(fragments, createTextFragment(translation.substring(startIndex, matchingIndex)));
+        fragments = addFragment(fragments, createPlaceholder(tagName, extract(content)));
+
+        startIndex = matchingIndex + fullMatch.length;
+    }
+    fragments = addFragment(fragments, createTextFragment(translation.substring(startIndex)));
+
+    return fragments;
+};
+
+export const replacePlaceholders = (translation, placeholders = {}) => {
+    const fragments = extract(translation);
+    let keyIndex = 0;
+
+    const replace = (fragment) => {
+        if (fragment.name) {
+            const placeholder = placeholders[fragment.name];
+            if (placeholder) {
+                if (typeof placeholder === 'function') {
+                    keyIndex++;
+                    const children = fragment.content.map(replace);
+                    return placeholder(children, `placeholder-${keyIndex}`);
+                }
+                return placeholder;
+            }
+
+            if (process.env.NODE_ENV !== 'production') {
+                console.error(
+                    `[React Intl] No placeholder named: ${fragment.name}`
+                );
+            }
+
+            return null;
+        }
+
+        return fragment.text;
+    };
+
+    return fragments.map(replace);
+};

--- a/test/unit/placeholders.js
+++ b/test/unit/placeholders.js
@@ -1,0 +1,43 @@
+import {replacePlaceholders} from '../../src/placeholders';
+
+describe('replacePlaceholders()', () => {
+    it('should return an array with the string', () => {
+        expect(replacePlaceholders('Some text')).toEqual(['Some text']);
+    });
+
+    it('should replace the static placeholder (can be an object)', () => {
+        expect(replacePlaceholders('Some <x:a>awful</x:a> text', {
+            a: {awe: 'some'},
+        })).toEqual(['Some ', {awe: 'some'}, ' text']);
+    });
+
+    it('should replace the dynamic placeholder', () => {
+        expect(replacePlaceholders('Some <x:a>awesome</x:a> text', {
+            a: (text) => text,
+        })).toEqual(['Some ', ['awesome'], ' text']);
+    });
+
+    it('should replace nested placeholders', () => {
+        expect(replacePlaceholders('Some <x:a> <x:b>inner</x:b> </x:a> text', {
+            a: (children) => children,
+            b: (children) => children,
+        })).toEqual(['Some ', [' ', ['inner'], ' '], ' text']);
+    });
+
+    it('should replace multiple placeholders', () => {
+        expect(replacePlaceholders('<x:a>one</x:a> <x:b>two</x:b>', {
+            a: (children) => children,
+            b: (children) => children,
+        })).toEqual([['one'], ' ', ['two']]);
+    });
+
+    it('should replace multiple placeholders with the same name', () => {
+        expect(replacePlaceholders('<x:a>one</x:a> <x:a>two</x:a>', {
+            a: (children) => children,
+        })).toEqual([['one'], ' ', ['two']]);
+    });
+
+    it('replace missing placeholder with null', () => {
+        expect(replacePlaceholders('<x:a>one</x:a>')).toEqual([null]);
+    });
+});

--- a/test/unit/placeholders.js
+++ b/test/unit/placeholders.js
@@ -17,6 +17,12 @@ describe('replacePlaceholders()', () => {
         })).toEqual(['Some ', ['awesome'], ' text']);
     });
 
+    it('should replace the placeholder with newline in the content', () => {
+        expect(replacePlaceholders('Some <x:a>awesome\n</x:a> text', {
+            a: (text) => text,
+        })).toEqual(['Some ', ['awesome\n'], ' text']);
+    });
+
     it('should replace nested placeholders', () => {
         expect(replacePlaceholders('Some <x:a> <x:b>inner</x:b> </x:a> text', {
             a: (children) => children,


### PR DESCRIPTION
This a first proposal for the rich text formatting (#513).

This implementation allows to replace some tags as described by Eric.
Eg: Your <x:0>email</x:0> has been sent.

This implementation has some drawbacks:
- the nested tags with the same name are not supported
- the self-closing tags are not supported

The previous React component interpolation does not change. I re-used the 'values' property to make the migration easier and to not change the sCU implementation.

The tags are parsed with RegExp and capturing groups.
I only tested the code against Firefox and Chrome.