### PR TITLE
[fix] Compatibility of injectIntl and static contextType

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     }
   },
   "dependencies": {
-    "hoist-non-react-statics": "^2.5.5",
+    "hoist-non-react-statics": "^3.2.1",
     "intl-format-cache": "^2.0.5",
     "intl-messageformat": "^2.1.0",
     "intl-relativeformat": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2298,9 +2298,12 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^2.5.5:
-  version "2.5.5"
-  resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
+hoist-non-react-statics@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz#c09c0555c84b38a7ede6912b61efddafd6e75e1e"
+  integrity sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==
+  dependencies:
+    react-is "^16.3.2"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3757,6 +3760,11 @@ react-element-to-jsx-string@^6.0.0:
     sortobject "^1.0.0"
     stringify-object "^3.1.0"
     traverse "^0.6.6"
+
+react-is@^16.3.2:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
+  integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
 
 react-test-renderer@^15.5.4:
   version "15.5.4"


### PR DESCRIPTION
React 16.6 introduces a new static `contextType`. If you use it in a component wrapped by injectIntl and old hoist-non-react-statics it will copy contextType to the wrapper component thus breaking context integration. Old versions were unaware of this so they would copy them through. React will then look at contextType and ignore contextTypes that injectIntl uses. It will then complain it can't find the context provided by react-intl.