### PR TITLE
#1211 - Deprecate withRef in favor of forwardRef and React.forwardRef

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "intl-messageformat": "^2.1.0",
     "intl-relativeformat": "^2.1.0",
     "invariant": "^2.1.1",
-    "react-display-name": "^0.2.4"
+    "react-display-name": "^0.2.4",
+    "react-is": "^16.3.1"
   },
   "peerDependencies": {
     "prop-types": "^15.5.4",

--- a/rollup.config.dist.js
+++ b/rollup.config.dist.js
@@ -41,6 +41,7 @@ export default {
     }),
     commonjs({
       sourcemap: true,
+      namedExports: {'react-is': ['isValidElementType']},
     }),
     replace({
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),

--- a/rollup.config.lib.js
+++ b/rollup.config.lib.js
@@ -27,7 +27,7 @@ export default {
   ],
   plugins: [
     babel(),
-    commonjs(),
+    commonjs({namedExports: {'react-is': ['isValidElementType']}}),
     nodeResolve({
       jsnext: true
     })

--- a/src/components/withIntl.js
+++ b/src/components/withIntl.js
@@ -1,4 +1,5 @@
 import React, {Component, createContext} from 'react';
+import {isValidElementType} from 'react-is';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import invariant from 'invariant';
 import {invariantIntlContext} from '../utils';
@@ -13,7 +14,17 @@ const {Consumer: IntlConsumer, Provider: IntlProvider} = IntlContext;
 export const Provider = IntlProvider;
 export const Context = IntlContext;
 
-export default function withIntl(WrappedComponent, options = {}) {
+export default function withIntl(componentOrOptions, options) {
+  if (isValidElementType(componentOrOptions)) {
+    // use call to make `options` available on `this`
+    return createWrapper.call({options}, componentOrOptions);
+  }
+  // return a function with `options` bound to `this`
+  return createWrapper.bind({options: componentOrOptions});
+}
+
+function createWrapper(WrappedComponent) {
+  let options = (this && this.options) || {};
   const {
     intlPropName = 'intl',
     forwardRef = false,

--- a/test/unit/components/withIntl.js
+++ b/test/unit/components/withIntl.js
@@ -140,5 +140,29 @@ describe('withIntl()', () => {
         expect(wrapperRef.current).toBe(wrapped.instance());
       });
     });
+
+    it('can also be used with a bound function', () => {
+      Wrapped = class extends React.Component {
+        render() {
+          return null;
+        }
+      };
+      const propName = 'myPropName';
+      const customWithIntl = withIntl({
+        forwardRef: true,
+        intlPropName: propName,
+      });
+      const wrapperRef = React.createRef();
+      const Injected = customWithIntl(Wrapped);
+
+      rendered = mountWithProvider(<Injected ref={wrapperRef} />);
+      const wrapped = rendered.find(Wrapped);
+
+      expect(wrapperRef.current).toBe(wrapped.instance());
+
+      const intlProvider = rendered.find(IntlProvider).childAt(0);
+
+      expect(wrapped.prop(propName)).toBe(intlProvider.instance().getContext());
+    });
   });
 });

--- a/test/unit/components/withIntl.js
+++ b/test/unit/components/withIntl.js
@@ -2,144 +2,143 @@ import expect, {spyOn} from 'expect';
 import React from 'react';
 import {mount} from 'enzyme';
 import {intlShape} from '../../../src/types';
-import IntlProvider from '../../../src/components/provider'
+import IntlProvider from '../../../src/components/provider';
 import withIntl from '../../../src/components/withIntl';
 
-const mountWithProvider = (el) => mount(
-  <IntlProvider locale='en'>
-    { el }
-  </IntlProvider>
-)
+const mountWithProvider = el =>
+  mount(<IntlProvider locale="en">{el}</IntlProvider>);
 
 describe('withIntl()', () => {
-    let Wrapped;
-    let rendered;
+  let Wrapped;
+  let rendered;
 
-    beforeEach(() => {
-        Wrapped = () => <div />;
-        Wrapped.displayName = 'Wrapped';
+  beforeEach(() => {
+    Wrapped = () => <div />;
+    Wrapped.displayName = 'Wrapped';
+    Wrapped.propTypes = {
+      intl: intlShape.isRequired,
+    };
+    Wrapped.someNonReactStatic = {
+      foo: true,
+    };
+    rendered = null;
+  });
+
+  afterEach(() => {
+    rendered && rendered.unmount();
+  });
+
+  it('allows introspection access to the wrapped component', () => {
+    expect(withIntl(Wrapped).WrappedComponent).toBe(Wrapped);
+  });
+
+  it('hoists non-react statics', () => {
+    expect(withIntl(Wrapped).someNonReactStatic.foo).toBe(true);
+  });
+
+  describe('displayName', () => {
+    it('is descriptive by default', () => {
+      expect(withIntl(() => null).displayName).toBe('withIntl(Component)');
+    });
+
+    it("includes `WrappedComponent`'s `displayName`", () => {
+      Wrapped.displayName = 'Foo';
+      expect(withIntl(Wrapped).displayName).toBe('withIntl(Foo)');
+    });
+  });
+
+  it('throws when <IntlProvider> is missing from ancestry', () => {
+    const Injected = withIntl(Wrapped);
+
+    const consoleError = spyOn(console, 'error'); // surpress console error from JSDom
+    expect(() => (rendered = mount(<Injected />))).toThrow(
+      '[React Intl] Could not find required `intl` object. <IntlProvider> needs to exist in the component ancestry.'
+    );
+    consoleError.restore();
+  });
+
+  it('renders <WrappedComponent> with `intl` prop', () => {
+    const Injected = withIntl(Wrapped);
+
+    rendered = mountWithProvider(<Injected />);
+    const wrappedComponent = rendered.find(Wrapped);
+    // React 16 renders different in the wrapper
+    const intlProvider = rendered.find(IntlProvider).childAt(0);
+
+    expect(wrappedComponent.prop('intl')).toBe(
+      intlProvider.instance().getContext()
+    );
+  });
+
+  it('propagates all props to <WrappedComponent>', () => {
+    const Injected = withIntl(Wrapped);
+    const props = {
+      foo: 'bar',
+    };
+
+    rendered = mountWithProvider(<Injected {...props} />);
+    const wrappedComponent = rendered.find(Wrapped);
+
+    Object.keys(props).forEach(key => {
+      expect(wrappedComponent.prop(key)).toBe(props[key]);
+    });
+  });
+
+  describe('options', () => {
+    describe('intlPropName', () => {
+      it("sets <WrappedComponent>'s `props[intlPropName]` to `context.intl`", () => {
+        const propName = 'myIntl';
         Wrapped.propTypes = {
-            intl: intlShape.isRequired,
+          [propName]: intlShape.isRequired,
         };
-        Wrapped.someNonReactStatic = {
-            foo: true
-        };
-        rendered = null;
-    });
-
-    afterEach(() => {
-      rendered && rendered.unmount();
-    })
-
-    it('allows introspection access to the wrapped component', () => {
-        expect(withIntl(Wrapped).WrappedComponent).toBe(Wrapped);
-    });
-
-    it('hoists non-react statics',() => {
-        expect(withIntl(Wrapped).someNonReactStatic.foo).toBe(true)
-    })
-
-    describe('displayName', () => {
-        it('is descriptive by default', () => {
-            expect(withIntl(() => null).displayName).toBe('withIntl(Component)');
+        const Injected = withIntl(Wrapped, {
+          intlPropName: propName,
         });
-
-        it('includes `WrappedComponent`\'s `displayName`', () => {
-            Wrapped.displayName = 'Foo';
-            expect(withIntl(Wrapped).displayName).toBe('withIntl(Foo)');
-        });
-    });
-
-    it('throws when <IntlProvider> is missing from ancestry', () => {
-        const Injected = withIntl(Wrapped);
-
-        const consoleError = spyOn(console, 'error'); // surpress console error from JSDom
-        expect(() => rendered = mount(<Injected />)).toThrow(
-            '[React Intl] Could not find required `intl` object. <IntlProvider> needs to exist in the component ancestry.'
-        );
-        consoleError.restore();
-    });
-
-    it('renders <WrappedComponent> with `intl` prop', () => {
-        const Injected = withIntl(Wrapped);
 
         rendered = mountWithProvider(<Injected />);
-        const wrappedComponent = rendered.find(Wrapped);
-        // React 16 renders different in the wrapper
+        const wrapped = rendered.find(Wrapped);
         const intlProvider = rendered.find(IntlProvider).childAt(0);
 
-        expect(
-            wrappedComponent.prop('intl')
-        ).toBe(intlProvider.instance().getContext());
+        expect(wrapped.prop(propName)).toBe(
+          intlProvider.instance().getContext()
+        );
+      });
     });
 
-    it('propagates all props to <WrappedComponent>', () => {
+    describe('withRef', () => {
+      it('throws when true', () => {
+        expect(() => withIntl(Wrapped, {withRef: true})).toThrow(
+          '[React Intl] withRef and getWrappedInstance() are deprecated, ' +
+            "instead use the 'forwardRef' option and create a ref directly on the wrapped component."
+        );
+      });
+    });
+
+    describe('forwardRef', () => {
+      it("doesn't forward the ref when forwardRef is `false`", () => {
         const Injected = withIntl(Wrapped);
-        const props = {
-          foo: 'bar'
-        }
+        const wrapperRef = React.createRef();
 
-        rendered = mountWithProvider(<Injected {...props} />);
-        const wrappedComponent = rendered.find(Wrapped);
+        rendered = mountWithProvider(<Injected ref={wrapperRef} />);
+        const wrapper = rendered.find(Injected);
 
-        Object.keys(props).forEach((key) => {
-          expect(wrappedComponent.prop(key)).toBe(props[key]);
-        })
+        expect(wrapperRef.current).toBe(wrapper.instance());
+      });
+
+      it('forwards the ref properly to the wrapped component', () => {
+        Wrapped = class extends React.Component {
+          render() {
+            return null;
+          }
+        };
+        const Injected = withIntl(Wrapped, {forwardRef: true});
+        const wrapperRef = React.createRef();
+
+        rendered = mountWithProvider(<Injected ref={wrapperRef} />);
+        const wrapped = rendered.find(Wrapped);
+
+        expect(wrapperRef.current).toBe(wrapped.instance());
+      });
     });
-
-    describe('options', () => {
-        describe('intlPropName', () => {
-            it('sets <WrappedComponent>\'s `props[intlPropName]` to `context.intl`', () => {
-                const propName = 'myIntl';
-                Wrapped.propTypes = {
-                  [propName]: intlShape.isRequired
-                };
-                const Injected = withIntl(Wrapped, {
-                  intlPropName: propName
-                });
-
-                rendered = mountWithProvider(<Injected />);
-                const wrapped = rendered.find(Wrapped);
-                // React 16 renders differently
-                const intlProvider = React.version.startsWith('16') ?
-                    rendered.find(IntlProvider).childAt(0) : rendered.find(IntlProvider).childAt(0).childAt(0);
-
-                expect(wrapped.prop(propName)).toBe(
-                    intlProvider.instance().getContext()
-                );
-            });
-        });
-
-        describe('withRef', () => {
-            it('throws when `false` and getWrappedInstance() is called', () => {
-                const Injected = withIntl(Wrapped);
-
-                rendered = mountWithProvider(<Injected />);
-                const wrapper = rendered.find(Injected);
-
-                expect(() => wrapper.instance().getWrappedInstance()).toThrow(
-                    '[React Intl] To access the wrapped instance, the `{withRef: true}` option must be set when calling: `withIntl()`'
-                );
-            });
-
-            it('does not throw when `true` getWrappedInstance() is called', () => {
-              Wrapped = class extends React.Component {
-                render () {
-                  return null
-                }
-              }
-
-              const Injected = withIntl(Wrapped, { withRef: true });
-
-              rendered = mountWithProvider(<Injected />);
-              const wrapper = rendered.find(Injected);
-              const wrapped = rendered.find(Wrapped);
-
-                expect(() => wrapper.instance().getWrappedInstance())
-                  .toNotThrow();
-                expect(wrapper.instance().getWrappedInstance())
-                  .toBe(wrapped.instance());
-            });
-        });
-    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5954,7 +5954,7 @@ react-dom@^16.3.3:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
+react-is@^16.3.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==


### PR DESCRIPTION
Deprecate withRef and use forwardRef prop instead.
When forwardRef is true, the ref passed to the injected component
will be passed down to the wrapped component.

Display a invariant message when withRef is used.

Closes #1211.

Since this is a breaking change it would be nice to have this for 3.0 :)