### PR TITLE
Remove deprecated lifecycles in FormattedRelative

### DIFF
--- a/src/components/relative.js
+++ b/src/components/relative.js
@@ -131,11 +131,11 @@ class FormattedRelative extends Component {
     this.scheduleNextUpdate(this.props, this.state);
   }
 
-  static getDerivedStateFromProps({ value }, { prevValue }) {
+  static getDerivedStateFromProps({ value, intl }, { prevValue }) {
     // When the `props.value` date changes, `state.now` needs to be updated,
     // and the next update can be rescheduled.
     if (!isSameDate(value, prevValue)) {
-      return {now: this.props.intl.now(), prevValue: value};
+      return {now: intl.now(), prevValue: value};
     }
     return null;
   }

--- a/src/components/relative.js
+++ b/src/components/relative.js
@@ -92,7 +92,7 @@ class FormattedRelative extends Component {
 
     // `now` is stored as state so that `render()` remains a function of
     // props + state, instead of accessing `Date.now()` inside `render()`.
-    this.state = {now};
+    this.state = {now, prevValue: props.value};
   }
 
   scheduleNextUpdate(props, state) {
@@ -131,20 +131,21 @@ class FormattedRelative extends Component {
     this.scheduleNextUpdate(this.props, this.state);
   }
 
-  componentWillReceiveProps({value: nextValue}) {
+  static getDerivedStateFromProps({ value }, { prevValue }) {
     // When the `props.value` date changes, `state.now` needs to be updated,
     // and the next update can be rescheduled.
-    if (!isSameDate(nextValue, this.props.value)) {
-      this.setState({now: this.props.intl.now()});
+    if (!isSameDate(value, prevValue)) {
+      return {now: this.props.intl.now(), prevValue: value};
     }
+    return null;
   }
 
   shouldComponentUpdate(...next) {
     return shouldIntlComponentUpdate(this, ...next);
   }
 
-  componentWillUpdate(nextProps, nextState) {
-    this.scheduleNextUpdate(nextProps, nextState);
+  componentDidUpdate() {
+    this.scheduleNextUpdate(this.props, this.state);
   }
 
   componentWillUnmount() {

--- a/test/unit/components/relative.js
+++ b/test/unit/components/relative.js
@@ -8,11 +8,11 @@ const mockContext = makeMockContext(
   require.resolve('../../../src/components/relative')
 );
 
-const spySetState = () => {
+const spyGetDerivedStateFromProps = () => {
   return spyOn(
-    require('../../../src/components/relative').BaseFormattedRelative.prototype,
-    'setState'
-  );
+    require('../../../src/components/relative').BaseFormattedRelative,
+    'getDerivedStateFromProps'
+  ).andCallThrough();
 }
 
 describe('<FormattedRelative>', () => {
@@ -20,19 +20,19 @@ describe('<FormattedRelative>', () => {
 
     let consoleError;
     let intl;
-    let setState;
+    let getDerivedStateFromProps;
 
     beforeEach(() => {
         consoleError = spyOn(console, 'error');
         intl = generateIntlContext({
           locale: 'en'
         });
-        setState = null;
+        getDerivedStateFromProps = null;
     });
 
     afterEach(() => {
         consoleError.restore();
-        setState && setState.restore();
+        getDerivedStateFromProps && getDerivedStateFromProps.restore();
     });
 
     it('has a `displayName`', () => {
@@ -48,14 +48,15 @@ describe('<FormattedRelative>', () => {
 
     it('requires a finite `value` prop', async () => {
         const FormattedRelative = mockContext(intl);
-        setState = spySetState();
+        getDerivedStateFromProps = spyGetDerivedStateFromProps();
 
-        expect(setState.calls.length).toBe(0);
+        expect(getDerivedStateFromProps.calls.length).toBe(0);
         const date = Date.now();
 
         const withIntlContext = mount(
           <FormattedRelative value={date} />
         );
+        console.log(consoleError.calls)
         expect(consoleError.calls.length).toBe(0);
 
         withIntlContext.setProps({
@@ -70,7 +71,8 @@ describe('<FormattedRelative>', () => {
 
         // Should avoid update scheduling tight-loop.
         await sleep(10);
-        expect(setState.calls.length).toBe(0, '`setState()` called unexpectedly');
+        // `getDerivedStateFromProps` is called on mount and when context updates.
+        expect(getDerivedStateFromProps.calls.length).toBe(2, '`getDerivedStateFromProps()` called unexpectedly');
 
         withIntlContext.unmount();
     });

--- a/test/unit/components/relative.js
+++ b/test/unit/components/relative.js
@@ -56,7 +56,6 @@ describe('<FormattedRelative>', () => {
         const withIntlContext = mount(
           <FormattedRelative value={date} />
         );
-        console.log(consoleError.calls)
         expect(consoleError.calls.length).toBe(0);
 
         withIntlContext.setProps({

--- a/test/unit/components/relative.js
+++ b/test/unit/components/relative.js
@@ -70,7 +70,7 @@ describe('<FormattedRelative>', () => {
 
         // Should avoid update scheduling tight-loop.
         await sleep(10);
-        expect(setState.calls.length).toBe(1, '`setState()` called unexpectedly');
+        expect(setState.calls.length).toBe(0, '`setState()` called unexpectedly');
 
         withIntlContext.unmount();
     });


### PR DESCRIPTION
This removes deprecated react 16 lifecycles.

- `componentWillUpdate` only performs a side effect (`setTimeout`) so it is fine to move it to `componentDidUpdate`.
- `componentWillReceiveProps` is replaced with `getDerivedStateFromProps`. The main change required is to save the previous value in state so we can check if it changed in `getDerivedStateFromProps`.
