### PR TITLE
fix babel config problem in examples #1274

### DIFF
--- a/examples/nested/.babelrc
+++ b/examples/nested/.babelrc
@@ -4,7 +4,8 @@
         "@babel/preset-react"
     ],
     "plugins": [
-        ["babel-plugin-transform-react-remove-prop-types", {
+        "babel-plugin-transform-react-remove-prop-types",
+        ["react-intl", {
             "messagesDir": "./build/messages/"
         }]
     ]

--- a/examples/translations/.babelrc
+++ b/examples/translations/.babelrc
@@ -4,7 +4,8 @@
         "@babel/preset-react"
     ],
     "plugins": [
-        ["babel-plugin-transform-react-remove-prop-types", {
+        "babel-plugin-transform-react-remove-prop-types",
+        ["react-intl", {
             "messagesDir": "./build/messages/"
         }]
     ]


### PR DESCRIPTION
There was a mistake inside .babelrc files about plugins part. I added `babel-plugin-react-intl` plugin inside .babelrc file as mentioned inside README.md file.

I tested examples they're working but the only case is there, we need to add dependencies manually maybe we could add them into package.json?