### PR TITLE
[feat] use intl-pluralrules

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "hoist-non-react-statics": "^3.3.0",
     "intl-format-cache": "^2.0.5",
     "intl-messageformat": "^2.1.0",
+    "intl-pluralrules": "^1.0.1",
     "intl-relativeformat": "^2.1.0",
     "invariant": "^2.1.1",
     "react-display-name": "^0.2.4"

--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -13,7 +13,6 @@ const DEFAULT_LOCALE = 'en';
 const CONCURRENCY = require('os').cpus().length - 1;
 
 const cldrData = extractCLDRData({
-  pluralRules: true,
   relativeFields: true,
 });
 

--- a/src/plural.js
+++ b/src/plural.js
@@ -4,25 +4,11 @@
  * See the accompanying LICENSE file for terms.
  */
 
-// This is a "hack" until a proper `intl-pluralformat` package is created.
-
-import IntlMessageFormat from 'intl-messageformat';
-
-function resolveLocale(locales) {
-  // IntlMessageFormat#_resolveLocale() does not depend on `this`.
-  return IntlMessageFormat.prototype._resolveLocale(locales);
-}
-
-function findPluralFunction(locale) {
-  // IntlMessageFormat#_findPluralFunction() does not depend on `this`.
-  return IntlMessageFormat.prototype._findPluralRuleFunction(locale);
-}
+import 'intl-pluralrules'
 
 export default class IntlPluralFormat {
   constructor(locales, options = {}) {
-    let useOrdinal = options.style === 'ordinal';
-    let pluralFn = findPluralFunction(resolveLocale(locales));
-
-    this.format = value => pluralFn(value, useOrdinal);
+    this.formatter = new Intl.PluralRules(locales, options)
   }
+  format = value => this.formatter.select(value)
 }

--- a/src/types.js
+++ b/src/types.js
@@ -110,5 +110,5 @@ export const relativeFormatPropTypes = {
 };
 
 export const pluralFormatPropTypes = {
-  style: oneOf(['cardinal', 'ordinal']),
+  type: oneOf(['cardinal', 'ordinal']),
 };


### PR DESCRIPTION
- Remove `pluralRules` extraction from `build-data` since `intl-pluralrules` comes with it.
- Fix `types` for plural to be more [spec-compliant](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules)