### PR TITLE
chore: remove uglify from cldr build

### DIFF
--- a/scripts/build-data.js
+++ b/scripts/build-data.js
@@ -5,7 +5,6 @@ import extractCLDRData from 'formatjs-extract-cldr-data';
 import serialize from 'serialize-javascript';
 import {rollup} from 'rollup';
 import virtual from 'rollup-plugin-virtual';
-import {uglify} from 'rollup-plugin-uglify';
 import ProgressBar from 'progress';
 import PromiseQueue from 'promise-queue';
 
@@ -42,7 +41,6 @@ function writeUMDFile(filename, module) {
       virtual({
         [filename]: module
       }),
-      uglify(),
     ],
   })
     .then(bundle => {


### PR DESCRIPTION
CLDR data doesn't need to be uglify because:
1. Relative Fields (for intl-relativeformat) data is JSON, which cannot be minified
2. Plural Rules from `make-plural` is already minified, e.g:
```
"pluralRuleFunction":function(n, ord
  ) {
    var s = String(n).split('.'), t0 = Number(s[0]) == n,
        n100 = t0 && s[0].slice(-2);
    if (ord) return 'other';
    return (n == 0) ? 'zero'
        : (n == 1) ? 'one'
        : (n == 2) ? 'two'
        : ((n100 >= 3 && n100 <= 10)) ? 'few'
        : ((n100 >= 11 && n100 <= 99)) ? 'many'
        : 'other';
  }
```

Speeds up the CLDR step by like 100x