### PR TITLE
#1224 - revert 736da31 and fix circular dependencies (useIntl hook)

### DIFF
--- a/src/components/useIntl.js
+++ b/src/components/useIntl.js
@@ -1,9 +1,9 @@
 import {useContext} from 'react';
-import {IntlContext} from './../react-intl';
+import {Context} from './withIntl';
 import {invariantIntlContext} from '../utils';
 
 export default function useIntl() {
-  const intl = useContext(IntlContext);
+  const intl = useContext(Context);
   invariantIntlContext({ intl });
-  return [intl.formatMessage,  intl];
+  return intl;
 }

--- a/test/unit/components/useIntl.js
+++ b/test/unit/components/useIntl.js
@@ -26,6 +26,6 @@ describe('useIntl() hook', () => {
       </IntlProvider>
     );
     const intl = rendered.find(IntlProvider).childAt(0).instance().getContext();
-    expect(spy).toHaveBeenCalledWith([intl.formatMessage, intl]);
+    expect(spy).toHaveBeenCalledWith(intl);
   });
 });


### PR DESCRIPTION
@DragonRaider5, @redonkulus,

Since these changes are trivially to be done and I'm the guy who introduce a bad implementation, I think I get the responsibility to make it great by nature.  Please let me know if that solve the issue or still have something I did not took cared.

Also, we were discussed to provide a shortcut as `useFormatMessage` hook since it's 90% use case, I personally okay with that since it looks neat and convenient. But as I said, I don't want to have that implemented and then people start to argue about why not `useFormatXXX` too... So maybe these shortcut should really do in the user's land?!  They can just wrap our useIntl hook to do whatever they want. 🤔

Finally, I would be curious how long a v3 beta should last since there are almost 0 PR now. Perhaps we can have an RC version for about a week then release v3?