### PR TITLE
fix: docs references

### DIFF
--- a/docs/Components.md
+++ b/docs/Components.md
@@ -137,7 +137,7 @@ type DateTimeFormatOptions = {
 
 ### `<FormattedDate>`
 
-This component uses the [`formatDate`](API#formatdate) and [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) APIs and has `props` that correspond to the `DateTimeFormatOptions` specified above.
+This component uses the [`formatDate`](API.md#formatdate) and [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) APIs and has `props` that correspond to the `DateTimeFormatOptions` specified above.
 
 **Props Types:**
 ```js
@@ -173,7 +173,7 @@ By default `<FormattedDate>` will render the formatted date into a `<span>`. If 
 
 ### `<FormattedTime>`
 
-This component uses the [`formatTime`](API#formattime) and [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) APIs and has `props` that correspond to the `DateTimeFormatOptions` specified above, with the following defaults:
+This component uses the [`formatTime`](API.md#formattime) and [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) APIs and has `props` that correspond to the `DateTimeFormatOptions` specified above, with the following defaults:
 
 ```js
 {
@@ -203,7 +203,7 @@ By default `<FormattedTime>` will render the formatted time into a `<span>`. If 
 
 ### `<FormattedRelative>`
 
-This component uses the [`formatRelative`](API#formatrelative) API and has `props` that correspond to the following relative formatting options:
+This component uses the [`formatRelative`](API.md#formatrelative) API and has `props` that correspond to the following relative formatting options:
 
 ```js
 type RelativeFormatOptions = {
@@ -252,7 +252,7 @@ React Intl provides two components to format numbers:
 
 ### `<FormattedNumber>`
 
-This component uses the [`formatNumber`](API#formatnumber) and [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat) APIs and has `props` that correspond to the following number formatting options:
+This component uses the [`formatNumber`](API.md#formatnumber) and [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat) APIs and has `props` that correspond to the following number formatting options:
 
 ```js
 type NumberFormatOptions = {
@@ -294,7 +294,7 @@ By default `<FormattedNumber>` will render the formatted number into a `<span>`.
 
 ### `<FormattedPlural>`
 
-This component uses the [`formatPlural`](API#formatplural) API and has `props` that correspond to the following plural formatting options:
+This component uses the [`formatPlural`](API.md#formatplural) API and has `props` that correspond to the following plural formatting options:
 
 ```js
 type PluralFormatOptions = {
@@ -377,7 +377,7 @@ type MessageDescriptor = {
 };
 ```
 
-A common practice is to use the [`defineMessages`](API#definemessages) API to define all of a component's strings, then _spread_ the Message Descriptor as props to the component.
+A common practice is to use the [`defineMessages`](API.md#definemessages) API to define all of a component's strings, then _spread_ the Message Descriptor as props to the component.
 
 **Note:** The [babel-plugin-react-intl](https://github.com/formatjs/formatjs/tree/master/packages/babel-plugin-react-intl) package can be used to extract Message Descriptors defined in JavaScript source files.
 
@@ -393,7 +393,7 @@ The message formatting APIs go the extra mile to provide fallbacks for the commo
 
 ### `<FormattedMessage>`
 
-This component uses the [`formatMessage`](API#formatmessage) API and has `props` that correspond to a [Message Descriptor](#message-descriptor).
+This component uses the [`formatMessage`](API.md#formatmessage) API and has `props` that correspond to a [Message Descriptor](#message-descriptor).
 
 **Props Types:**
 ```js
@@ -460,7 +460,7 @@ This allows messages to still be defined as a plain string _without_ HTML — ma
 
 **Note:** This component is provided for apps that have legacy external strings which contain HTML, but is not recommended, use [`<FormattedMessage>`](#formattedmessage) instead, if you can.
 
-This component uses the [`formatHTMLMessage`](API#formathtmlmessage) API and has the same props as `<FormattedMessage>`, but it will accept messages that contain HTML. In order to protect against XSS, all string `values` will be HTML-escaped and the resulting formatted message will be set via `dangerouslySetInnerHTML`. This means that `values` _cannot_ contain React element like `<FormattedMessage>` and this component will be less performant.
+This component uses the [`formatHTMLMessage`](API.md#formathtmlmessage) API and has the same props as `<FormattedMessage>`, but it will accept messages that contain HTML. In order to protect against XSS, all string `values` will be HTML-escaped and the resulting formatted message will be set via `dangerouslySetInnerHTML`. This means that `values` _cannot_ contain React element like `<FormattedMessage>` and this component will be less performant.
 
 ### Using React-Intl with React Native
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -81,18 +81,18 @@ We've made React Intl work well with module bundlers like: Browserify, Webpack, 
 
 Whether you use the ES6, CommonJS, or UMD version of React Intl, they all provide the same named exports:
 
-- [`addLocaleData`](API#addlocaledata)
-- [`intlShape`](API#intlshape)
-- [`injectIntl`](API#injectintl)
-- [`defineMessages`](API#definemessages)
-- [`IntlProvider`](Components#intlprovider)
-- [`FormattedDate`](Components#formatteddate)
-- [`FormattedTime`](Components#formattedtime)
-- [`FormattedRelative`](Components#formattedrelative)
-- [`FormattedNumber`](Components#formattednumber)
-- [`FormattedPlural`](Components#formattedplural)
-- [`FormattedMessage`](Components#formattedmessage)
-- [`FormattedHTMLMessage`](Components#formattedhtmlmessage)
+- [`addLocaleData`](API.md#addlocaledata)
+- [`intlShape`](API.md#intlshape)
+- [`injectIntl`](API.md#injectintl)
+- [`defineMessages`](API.md#definemessages)
+- [`IntlProvider`](Components.md#intlprovider)
+- [`FormattedDate`](Components.md#formatteddate)
+- [`FormattedTime`](Components.md#formattedtime)
+- [`FormattedRelative`](Components.md#formattedrelative)
+- [`FormattedNumber`](Components.md#formattednumber)
+- [`FormattedPlural`](Components.md#formattedplural)
+- [`FormattedMessage`](Components.md#formattedmessage)
+- [`FormattedHTMLMessage`](Components.md#formattedhtmlmessage)
 
 **Note:** When using the UMD version of React Intl _without_ a module system, it will expect `react` to exist on the global variable: __`React`__, and put the above named exports on the global variable: __`ReactIntl`__.
 
@@ -174,7 +174,7 @@ ReactDOM.render(
 
 React Intl has two ways to format data, through [React components][Components] and its [API][API]. The components provide an idiomatic-React way of integrating internationalization into a React app, and the `<Formatted*>` components have [benefits](./Components.md#why-components) over always using the imperative API directly. The API should be used when your React component needs to format data to a string value where a React element is not suitable; e.g., a `title` or `aria` attribute, or for side-effect in `componentDidMount`.
 
-React Intl's imperative API is accessed via [__`injectIntl`__](API#injectintl), a High-Order Component (HOC) factory. It will wrap the passed-in React component with another React component which provides the imperative formatting API into the wrapped component via its `props`. (This is similar to the connect-to-stores pattern found in many Flux implementations.)
+React Intl's imperative API is accessed via [__`injectIntl`__](API.md#injectintl), a High-Order Component (HOC) factory. It will wrap the passed-in React component with another React component which provides the imperative formatting API into the wrapped component via its `props`. (This is similar to the connect-to-stores pattern found in many Flux implementations.)
 
 Here's an example using `<IntlProvider>`, `<Formatted*>` components, and the imperative API to setup an i18n context and format data:
 

--- a/docs/Upgrade-Guide.md
+++ b/docs/Upgrade-Guide.md
@@ -133,7 +133,7 @@ The locale data modules in React Intl v2 have been refactored to _provide_ data,
 
 #### Add Call to `addLocaleData()` in Browser
 
-There is now an [`addLocaleData()`](API#addlocaledata) function that needs to be called with the locale data that has been loaded. You can do the following in your main client JavaScript entry point:
+There is now an [`addLocaleData()`](API.md#addlocaledata) function that needs to be called with the locale data that has been loaded. You can do the following in your main client JavaScript entry point:
 
 This assumes a locale data `<script>` is added based on the request; e.g., for French speaking users:
 
@@ -165,7 +165,7 @@ if ('ReactIntlLocaleData' in window) {
 
 ### Remove Intl Mixin
 
-**The `IntlMixin` has been removed from React Intl v2.** The mixin did two things: it automatically propagated `locales`, `formats`, and `messages` throughout an app's hierarchy, and it provided an imperative API via `format*()` functions. These jobs are now handled by [`<IntlProvider>`](Components#intlprovider) and [`injectIntl()`](API#injection-api), respectively:
+**The `IntlMixin` has been removed from React Intl v2.** The mixin did two things: it automatically propagated `locales`, `formats`, and `messages` throughout an app's hierarchy, and it provided an imperative API via `format*()` functions. These jobs are now handled by [`<IntlProvider>`](Components#intlprovider) and [`injectIntl()`](API.md#injection-api), respectively:
 
 #### Update to `<IntlProvider>`
 
@@ -187,9 +187,9 @@ ReactDOM.render(
 
 #### Update to `injectIntl()`
 
-The `IntlMixin` also provided the imperative API for custom components to use the `format*()` methods; e.g., `formatDate()` to get formatted strings for using in places like `title` and `aria` attribute. Remove the `IntlMixin` and instead use the [`injectIntl()`](API#injectintl) Hight Order Component (HOC) factory function to inject the imperative API via `props`.
+The `IntlMixin` also provided the imperative API for custom components to use the `format*()` methods; e.g., `formatDate()` to get formatted strings for using in places like `title` and `aria` attribute. Remove the `IntlMixin` and instead use the [`injectIntl()`](API.md#injectintl) Hight Order Component (HOC) factory function to inject the imperative API via `props`.
 
-Here's an example of a custom `<RelativeTime>` stateless component which uses `injectIntl()` and the imperative [`formatDate()`](API#formatdate) API:
+Here's an example of a custom `<RelativeTime>` stateless component which uses `injectIntl()` and the imperative [`formatDate()`](API.md#formatdate) API:
 
 ```js
 import React from 'react';
@@ -232,7 +232,7 @@ export default injectIntl(RelativeTime);
 
 **The way string messages are formatted in React Intl v2 has changed significantly!** This is the most disruptive set of change when upgrading from v1 to v2; but it enables many great new features.
 
-React Intl v2 introduces a new [**Message Descriptor**](API#message-descriptor) concept which can be used to define an app's default string messages. A Message Descriptor is an object with the following properties, `id` is the only required prop:
+React Intl v2 introduces a new [**Message Descriptor**](API.md#message-descriptor) concept which can be used to define an app's default string messages. A Message Descriptor is an object with the following properties, `id` is the only required prop:
 
 - **`id`**: A unique, stable identifier for the message
 - **`description`**: Context for the translator about how it's used in the UI
@@ -297,7 +297,7 @@ let message = this.formatMessage(this.getIntlMessage('some.message.id'), values)
 let message = this.props.intl.formatMessage({id: 'some.message.id'}, values);
 ```
 
-**Note:** In React Intl v2, the [`formatMessage()`](API#formatmessage) function is injected via [`injectIntl()`](API#injectintl).
+**Note:** In React Intl v2, the [`formatMessage()`](API.md#formatmessage) function is injected via [`injectIntl()`](API.md#injectintl).
 
 #### Update `<FormattedMessage>` and `<FormattedHTMLMessage>` Instances
 
@@ -360,4 +360,4 @@ let relative = this.props.intl.formatRelative(date, {
 });
 ```
 
-**Note:** In React Intl v2, the [`formatRelative()`](API#formatrelative) function is injected via [`injectIntl()`](API#injectintl).
+**Note:** In React Intl v2, the [`formatRelative()`](API.md#formatrelative) function is injected via [`injectIntl()`](API.md#injectintl).


### PR DESCRIPTION
Markdown variables seem not working in links.