### PR TITLE
Remove .prettierignore file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-src/en.js


### PR DESCRIPTION
The `src/en.js` is no longer generated by #1301, then this file isn't needed for now.