### PR TITLE
Format markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,16 @@
-Contributing
-============
+# Contributing
 
 Pull requests are very welcome, but should be within the scope of the project, and follow the repository's code conventions. Before submitting a pull request, it's always good to file an issue, so we can discuss the details of the PR.
 
 ## Reporting a Bug
 
-1. Ensure you've replicated the issue against master.  There is a chance the issue may have already been fixed.
+1. Ensure you've replicated the issue against master. There is a chance the issue may have already been fixed.
 
-2. Search for any similar issues (both opened and closed).  There is a chance someone may have reported it already.
+2. Search for any similar issues (both opened and closed). There is a chance someone may have reported it already.
 
-3. Provide a demo of the bug isolated in a jsfiddle/jsbin.  Sometimes this is not a possibility, in which case provide a detailed description along with any code snippets that would help in triaging the issue.  If we cannot reproduce it, we will close it.
+3. Provide a demo of the bug isolated in a jsfiddle/jsbin. Sometimes this is not a possibility, in which case provide a detailed description along with any code snippets that would help in triaging the issue. If we cannot reproduce it, we will close it.
 
-4. The best way to demonstrate a bug is to build a failing test.  This is not required, however, it will generally speed up the development process.
+4. The best way to demonstrate a bug is to build a failing test. This is not required, however, it will generally speed up the development process.
 
 ## Submitting a pull request
 
@@ -27,7 +26,7 @@ Pull requests are very welcome, but should be within the scope of the project, a
 
 5. Follow syntax guidelines detailed below.
 
-6. Push the changes to your fork and submit a pull request.  If this resolves any issues, please mark in the body `resolve #ID` within the body of your pull request.  This allows for github to automatically close the related issue once the pull request is merged.
+6. Push the changes to your fork and submit a pull request. If this resolves any issues, please mark in the body `resolve #ID` within the body of your pull request. This allows for github to automatically close the related issue once the pull request is merged.
 
 7. Last step, [submit the pull request][pr]!
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-React Intl
-==========
+# React Intl
 
 Internationalize [React][] apps. This library provides React components and an API to format dates, numbers, and strings, including pluralization and handling translations.
 
@@ -7,9 +6,7 @@ Internationalize [React][] apps. This library provides React components and an A
 [![Build Status][travis-badge]][travis]
 [![Dependency Status][david-badge]][david]
 
-
-Overview
---------
+## Overview
 
 **React Intl is part of [FormatJS][].** It provides bindings to React via its components and API.
 
@@ -18,7 +15,7 @@ You can sign-up using this [invitation link](https://join.slack.com/t/formatjs/s
 
 ### [Documentation][]
 
-React Intl's docs are in this GitHub [`/docs`][Documentation] folder, [__Get Started__][Getting Started]. There are also several [runnable example apps][Examples] which you can reference to learn how all the pieces fit together.
+React Intl's docs are in this GitHub [`/docs`][documentation] folder, [**Get Started**][getting started]. There are also several [runnable example apps][examples] which you can reference to learn how all the pieces fit together.
 
 _(If you're looking for React Intl v1, you can find it [here][v1-docs].)_
 
@@ -34,7 +31,7 @@ _(If you're looking for React Intl v1, you can find it [here][v1-docs].)_
 
 ### Example
 
-There are several [runnable examples][Examples] in this Git repo, but here's a Hello World one:
+There are several [runnable examples][examples] in this Git repo, but here's a Hello World one:
 
 ```js
 import React, {Component} from 'react';
@@ -42,39 +39,38 @@ import ReactDOM from 'react-dom';
 import {IntlProvider, FormattedMessage} from 'react-intl';
 
 class App extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            name       : 'Eric',
-            unreadCount: 1000,
-        };
-    }
+  constructor(props) {
+    super(props);
+    this.state = {
+      name: 'Eric',
+      unreadCount: 1000,
+    };
+  }
 
-    render() {
-        const {name, unreadCount} = this.state;
+  render() {
+    const {name, unreadCount} = this.state;
 
-        return (
-            <p>
-                <FormattedMessage
-                    id="welcome"
-                    defaultMessage={`Hello {name}, you have {unreadCount, number} {unreadCount, plural,
+    return (
+      <p>
+        <FormattedMessage
+          id="welcome"
+          defaultMessage={`Hello {name}, you have {unreadCount, number} {unreadCount, plural,
                       one {message}
                       other {messages}
                     }`}
-                    values={{name: <b>{name}</b>, unreadCount}}
-                />
-            </p>
-        );
-    }
+          values={{name: <b>{name}</b>, unreadCount}}
+        />
+      </p>
+    );
+  }
 }
 
 ReactDOM.render(
-    <IntlProvider locale="en">
-        <App />
-    </IntlProvider>,
-    document.getElementById('container')
+  <IntlProvider locale="en">
+    <App />
+  </IntlProvider>,
+  document.getElementById('container')
 );
-
 ```
 
 This example would render: "Hello **Eric**, you have 1,000 messages." into the container element on the page.
@@ -82,20 +78,16 @@ This example would render: "Hello **Eric**, you have 1,000 messages." into the c
 **Pluralization rules:** In some languages you have more than `one` and `other`. For example in `ru` there are the following plural rules: `one`, `few`, `many` and `other`.
 Check out the official [Unicode CLDR documentation](http://www.unicode.org/cldr/charts/28/supplemental/language_plural_rules.html).
 
-Contribute
----------
+## Contribute
 
-Let's make React Intl and FormatJS better! If you're interested in helping, all contributions are welcome and appreciated. React Intl is just one of many packages that make up the [FormatJS suite of packages][FormatJS GitHub], and you can contribute to any/all of them, including the [Format JS website][FormatJS] itself.
+Let's make React Intl and FormatJS better! If you're interested in helping, all contributions are welcome and appreciated. React Intl is just one of many packages that make up the [FormatJS suite of packages][formatjs github], and you can contribute to any/all of them, including the [Format JS website][formatjs] itself.
 
-Check out the [Contributing document][CONTRIBUTING] for the details. Thanks!
+Check out the [Contributing document][contributing] for the details. Thanks!
 
-
-License
--------
+## License
 
 This software is free to use under the Yahoo Inc. BSD license.
 See the [LICENSE file][] for license text and copyright information.
-
 
 [npm]: https://www.npmjs.org/package/react-intl
 [npm-badge]: https://img.shields.io/npm/v/react-intl.svg?style=flat-square
@@ -103,12 +95,12 @@ See the [LICENSE file][] for license text and copyright information.
 [david-badge]: https://img.shields.io/david/formatjs/react-intl.svg?style=flat-square
 [travis]: https://travis-ci.org/formatjs/react-intl
 [travis-badge]: https://img.shields.io/travis/formatjs/react-intl/master.svg?style=flat-square
-[React]: http://facebook.github.io/react/
-[FormatJS]: http://formatjs.io/
-[FormatJS GitHub]: http://formatjs.io/github/
-[Documentation]: https://github.com/formatjs/react-intl/blob/master/docs/README.md
-[Getting Started]: https://github.com/formatjs/react-intl/blob/master/docs/Getting-Started.md
-[Examples]: https://github.com/formatjs/react-intl/tree/master/examples
+[react]: http://facebook.github.io/react/
+[formatjs]: http://formatjs.io/
+[formatjs github]: http://formatjs.io/github/
+[documentation]: https://github.com/formatjs/react-intl/blob/master/docs/README.md
+[getting started]: https://github.com/formatjs/react-intl/blob/master/docs/Getting-Started.md
+[examples]: https://github.com/formatjs/react-intl/tree/master/examples
 [v1-docs]: http://formatjs.io/react/v1/
-[CONTRIBUTING]: https://github.com/formatjs/react-intl/blob/master/CONTRIBUTING.md
-[LICENSE file]: https://github.com/formatjs/react-intl/blob/master/LICENSE.md
+[contributing]: https://github.com/formatjs/react-intl/blob/master/CONTRIBUTING.md
+[license file]: https://github.com/formatjs/react-intl/blob/master/LICENSE.md

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API
 
-There are a few API layers that React Intl provides and is built on. When using React Intl you'll be interacting with its API (documented here) and its React [components][Components].
+There are a few API layers that React Intl provides and is built on. When using React Intl you'll be interacting with its API (documented here) and its React [components][components].
 
 1. [ECMAScript Internationalization API](#ecmascript-internationalization-api)
 2. [FormatJS Internationalization Formatters](#formatjs-internationalization-formatters)
@@ -80,11 +80,11 @@ This function is exported by the `react-intl` package and is simply a _hook_ for
 import {defineMessages} from 'react-intl';
 
 const messages = defineMessages({
-    greeting: {
-        id: 'app.home.greeting',
-        description: 'Message to greet the user.',
-        defaultMessage: 'Hello, {name}!',
-    },
+  greeting: {
+    id: 'app.home.greeting',
+    description: 'Message to greet the user.',
+    defaultMessage: 'Hello, {name}!',
+  },
 });
 ```
 
@@ -113,14 +113,14 @@ import React, {PropTypes} from 'react';
 import {injectIntl, intlShape, FormattedRelative} from 'react-intl';
 
 const Component = ({date, intl}) => (
-    <span title={intl.formatDate(date)}>
-        <FormattedRelative value={date}/>
-    </span>
+  <span title={intl.formatDate(date)}>
+    <FormattedRelative value={date} />
+  </span>
 );
 
 Component.propTypes = {
-    date: PropTypes.any.isRequired,
-    intl: intlShape.isRequired,
+  date: PropTypes.any.isRequired,
+  intl: intlShape.isRequired,
 };
 
 export default injectIntl(Component);
@@ -155,9 +155,9 @@ This function is exported by the `react-intl` package and provides an object-sha
 
 The definition above shows what the `props.intl` object will look like that's injected to your component via `injectintl`. It's made up of three parts:
 
-- __`IntlConfig`:__ The intl metadata passed as props into the parent `<IntlProvider>`.
-- __`IntlFormat`:__ The imperative formatting API described below.
-- __`now`:__ A function that returns the current time.
+- **`IntlConfig`:** The intl metadata passed as props into the parent `<IntlProvider>`.
+- **`IntlFormat`:** The imperative formatting API described below.
+- **`now`:** A function that returns the current time.
 
 ### Date Formatting APIs
 
@@ -206,9 +206,9 @@ This function will return a formatted date string. It expects a `value` which ca
 
 ```js
 formatDate(Date.now(), {
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric',
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
 }); // "3/4/2016"
 ```
 
@@ -222,6 +222,7 @@ function formatTime(
 ```
 
 This function will return a formatted date string, but it differs from [`formatDate`](#formatdate) by having the following default options:
+
 ```js
 {
     hour: 'numeric',
@@ -355,11 +356,13 @@ These APIs are used by their corresponding `<FormattedMessage>`, and `<Formatted
 String/Message formatting is a paramount feature of React Intl and it builds on [ICU Message Formatting](http://userguide.icu-project.org/formatparse/messages) by using the [ICU Message Syntax](http://formatjs.io/guides/message-syntax/). This message syntax allows for simple to complex messages to be defined, translated, and then formatted at runtime.
 
 **Simple Message:**
+
 ```
 Hello, {name}
 ```
 
 **Complex Message:**
+
 ```
 Hello, {name}, you have {itemCount, plural,
     =0 {no items}
@@ -374,15 +377,15 @@ Hello, {name}, you have {itemCount, plural,
 
 React Intl has a Message Descriptor concept which is used to define your app's default messages/strings and is passed into `formatMessage` and `formatHTMLMessage`. The Message Descriptors work very well for providing the data necessary for having the strings/messages translated, and they contain the following properties:
 
-- __`id`:__ A unique, stable identifier for the message
-- __`description`:__ Context for the translator about how it's used in the UI
-- __`defaultMessage`:__ The default message (probably in English)
+- **`id`:** A unique, stable identifier for the message
+- **`description`:** Context for the translator about how it's used in the UI
+- **`defaultMessage`:** The default message (probably in English)
 
 ```js
 type MessageDescriptor = {
-    id: string,
-    defaultMessage?: string,
-    description?: string | object,
+  id: string,
+  defaultMessage?: string,
+  description?: string | object,
 };
 ```
 
@@ -415,11 +418,11 @@ If a translated message with the `id` has been passed to the `<IntlProvider>` vi
 
 ```js
 const messages = defineMessages({
-    greeting: {
-        id: 'app.greeting',
-        defaultMessage: 'Hello, {name}!',
-        description: 'Greeting to welcome the user to the app',
-    },
+  greeting: {
+    id: 'app.greeting',
+    defaultMessage: 'Hello, {name}!',
+    description: 'Greeting to welcome the user to the app',
+  },
 });
 
 formatMessage(messages.greeting, {name: 'Eric'}); // "Hello, Eric!"
@@ -444,6 +447,6 @@ function formatHTMLMessage(
 
 The React components provided by React Intl allow for a declarative, idiomatic-React way of providing internationalization configuration and format dates, numbers, and strings/messages in your app.
 
-**See:** The [Components][Components] page.
+**See:** The [Components][components] page.
 
-[Components]: Components.md
+[components]: Components.md

--- a/docs/Components.md
+++ b/docs/Components.md
@@ -53,6 +53,7 @@ type IntlConfig = {
 These configuration props are combined with the `<IntlProvider>`'s component-specific props:
 
 **Prop Types:**
+
 ```js
 props: IntlConfig & {
     children: ReactElement,
@@ -65,27 +66,30 @@ props: IntlConfig & {
 Finally, a **single child** element _must_ be supplied to `<IntlProvider>`.
 
 **Example:**
+
 ```js
 const App = ({importantDate}) => (
-    <div>
-        <FormattedDate
-            value={importantDate}
-            year='numeric'
-            month='long'
-            day='numeric'
-            weekday='long'
-        />
-    </div>
+  <div>
+    <FormattedDate
+      value={importantDate}
+      year="numeric"
+      month="long"
+      day="numeric"
+      weekday="long"
+    />
+  </div>
 );
 
 ReactDOM.render(
-    <IntlProvider locale={navigator.language}>
-        <App importantDate={new Date(1459913574887)}/>
-    </IntlProvider>,
-    document.getElementById('container')
+  <IntlProvider locale={navigator.language}>
+    <App importantDate={new Date(1459913574887)} />
+  </IntlProvider>,
+  document.getElementById('container')
 );
 ```
+
 Assuming `navigator.language` is `"fr"`:
+
 ```html
 <div><span>mardi 5 avril 2016</span></div>
 ```
@@ -103,6 +107,7 @@ By default, changes to the `locale` at runtime may not trigger a re-render of ch
   <App />
 </IntlProvider>
 ```
+
 (See [Issue #243](https://github.com/formatjs/react-intl/issues/243).)
 
 ## Date Formatting Components
@@ -140,6 +145,7 @@ type DateTimeFormatOptions = {
 This component uses the [`formatDate`](API.md#formatdate) and [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) APIs and has `props` that correspond to the `DateTimeFormatOptions` specified above.
 
 **Props Types:**
+
 ```js
 props: DateTimeFormatOptions & {
     value: any,
@@ -151,22 +157,26 @@ props: DateTimeFormatOptions & {
 By default `<FormattedDate>` will render the formatted date into a `<span>`. If you need to customize rendering, you can either wrap it with another React element (recommended), or pass a function as the child.
 
 **Example:**
+
 ```js
-<FormattedDate value={new Date(1459832991883)}/>
+<FormattedDate value={new Date(1459832991883)} />
 ```
+
 ```html
 <span>4/5/2016</span>
 ```
 
 **Example with Options:**
+
 ```js
 <FormattedDate
   value={new Date(1459832991883)}
-  year='numeric'
-  month='long'
-  day='2-digit'
+  year="numeric"
+  month="long"
+  day="2-digit"
 />
 ```
+
 ```html
 <span>April 05, 2016</span>
 ```
@@ -183,6 +193,7 @@ This component uses the [`formatTime`](API.md#formattime) and [`Intl.DateTimeFor
 ```
 
 **Props Types:**
+
 ```js
 props: DateTimeFormatOptions & {
     value: any,
@@ -194,9 +205,11 @@ props: DateTimeFormatOptions & {
 By default `<FormattedTime>` will render the formatted time into a `<span>`. If you need to customize rendering, you can either wrap it with another React element (recommended), or pass a function as the child.
 
 **Example:**
+
 ```js
-<FormattedTime value={new Date(1459832991883)}/>
+<FormattedTime value={new Date(1459832991883)} />
 ```
+
 ```html
 <span>1:09 AM</span>
 ```
@@ -213,6 +226,7 @@ type RelativeFormatOptions = {
 ```
 
 **Prop Types:**
+
 ```js
 props: RelativeFormatOptions & {
     value: any,
@@ -226,17 +240,23 @@ props: RelativeFormatOptions & {
 By default `<FormattedRelative>` will render the formatted relative time into a `<span>`, **and update it a maximum of every 10 seconds**. If you need to customize rendering, you can either wrap it with another React element (recommended), or pass a function as the child.
 
 **Example:**
+
 ```js
-<FormattedRelative value={Date.now()}/>
+<FormattedRelative value={Date.now()} />
 ```
+
 ```html
 <span>now</span>
 ```
+
 …10 seconds later:
+
 ```html
 <span>10 seconds ago</span>
 ```
+
 …60 seconds later:
+
 ```html
 <span>1 minute ago</span>
 ```
@@ -274,6 +294,7 @@ type NumberFormatOptions = {
 ```
 
 **Props Types:**
+
 ```js
 props: NumberFormatOptions & {
     value: any,
@@ -285,9 +306,11 @@ props: NumberFormatOptions & {
 By default `<FormattedNumber>` will render the formatted number into a `<span>`. If you need to customize rendering, you can either wrap it with another React element (recommended), or pass a function as the child.
 
 **Example:**
+
 ```js
-<FormattedNumber value={1000}/>
+<FormattedNumber value={1000} />
 ```
+
 ```html
 <span>1,000</span>
 ```
@@ -303,6 +326,7 @@ type PluralFormatOptions = {
 ```
 
 **Props Types:**
+
 ```js
 props: PluralFormatOptions & {
     value: any,
@@ -321,13 +345,11 @@ props: PluralFormatOptions & {
 By default `<FormattedPlural>` will select a [plural category](http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html) (`zero`, `one`, `two`, `few`, `many`, or `other`) and render the corresponding React element into a `<span>`. If you need to customize rendering, you can either wrap it with another React element (recommended), or pass a function as the child.
 
 **Example:**
+
 ```js
-<FormattedPlural
-    value={10}
-    one='message'
-    other='messages'
-/>
+<FormattedPlural value={10} one="message" other="messages" />
 ```
+
 ```html
 <span>messages</span>
 ```
@@ -346,11 +368,13 @@ It is recommended that you use `<FormattedMessage>` because it provides greater 
 String/Message formatting is a paramount feature of React Intl and it builds on [ICU Message Formatting](http://userguide.icu-project.org/formatparse/messages) by using the [ICU Message Syntax](http://formatjs.io/guides/message-syntax/). This message syntax allows for simple to complex messages to be defined, translated, and then formatted at runtime.
 
 **Simple Message:**
+
 ```
 Hello, {name}
 ```
 
 **Complex Message:**
+
 ```
 Hello, {name}, you have {itemCount, plural,
     =0 {no items}
@@ -365,15 +389,15 @@ Hello, {name}, you have {itemCount, plural,
 
 React Intl has a Message Descriptor concept which is used to define your app's default messages/strings. `<FormattedMessage>` and `<FormattedHTMLMessage>` have props which correspond to a Message Descriptor. The Message Descriptors work very well for providing the data necessary for having the strings/messages translated, and they contain the following properties:
 
-- __`id`:__ A unique, stable identifier for the message
-- __`description`:__ Context for the translator about how it's used in the UI
-- __`defaultMessage`:__ The default message (probably in English)
+- **`id`:** A unique, stable identifier for the message
+- **`description`:** Context for the translator about how it's used in the UI
+- **`defaultMessage`:** The default message (probably in English)
 
 ```js
 type MessageDescriptor = {
-    id: string,
-    defaultMessage?: string,
-    description?: string | object,
+  id: string,
+  defaultMessage?: string,
+  description?: string | object,
 };
 ```
 
@@ -396,6 +420,7 @@ The message formatting APIs go the extra mile to provide fallbacks for the commo
 This component uses the [`formatMessage`](API.md#formatmessage) API and has `props` that correspond to a [Message Descriptor](#message-descriptor).
 
 **Props Types:**
+
 ```js
 props: MessageDescriptor & {
     values?: object,
@@ -407,29 +432,28 @@ props: MessageDescriptor & {
 By default `<FormattedMessage>` will render the formatted string into a `<span>`. If you need to customize rendering, you can either wrap it with another React element (recommended), specify a different `tagName` (e.g., `'div'`), or pass a function as the child.
 
 **Example:**
+
 ```js
 <FormattedMessage
-    id='app.greeting'
-    description='Greeting to welcome the user to the app'
-    defaultMessage='Hello, {name}!'
-    values={{
-        name: 'Eric'
-    }}
+  id="app.greeting"
+  description="Greeting to welcome the user to the app"
+  defaultMessage="Hello, {name}!"
+  values={{
+    name: 'Eric',
+  }}
 />
 ```
+
 ```html
 <span>Hello, Eric!</span>
 ```
+
 **Example:** function as the child
+
 ```js
-<FormattedMessage id="title">
-    {(txt) => (
-        <H1>
-            {txt}
-        </H1>
-    )}
-</FormattedMessage>
+<FormattedMessage id="title">{txt => <H1>{txt}</H1>}</FormattedMessage>
 ```
+
 ```html
 <h1>Hello, Eric!</h1>
 ```
@@ -442,14 +466,15 @@ By default `<FormattedMessage>` will render the formatted string into a `<span>`
 
 ```js
 <FormattedMessage
-    id='app.greeting'
-    description='Greeting to welcome the user to the app'
-    defaultMessage='Hello, {name}!'
-    values={{
-        name: <b>Eric</b>
-    }}
+  id="app.greeting"
+  description="Greeting to welcome the user to the app"
+  defaultMessage="Hello, {name}!"
+  values={{
+    name: <b>Eric</b>,
+  }}
 />
 ```
+
 ```html
 <span>Hello, <b>Eric</b>!</span>
 ```

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -50,15 +50,15 @@ $ npm install react-intl --save
 
 The `react-intl` npm package distributes the following modules (links from [unpkg](https://unpkg.com/)):
 
-- [__CommonJS__](https://unpkg.com/react-intl@latest/lib/index.js):
+- [**CommonJS**](https://unpkg.com/react-intl@latest/lib/index.js):
   unbundled dependencies, `"main"` in `package.json`, warnings in dev.
-- [__ES6__](https://unpkg.com/react-intl@latest/lib/index.es.js):
+- [**ES6**](https://unpkg.com/react-intl@latest/lib/index.es.js):
   unbundled dependencies, `"jsnext:main"` and `"module"` in `package.json`, warnings in dev.
-- [__UMD dev__](https://unpkg.com/react-intl@latest/dist/react-intl.js):
+- [**UMD dev**](https://unpkg.com/react-intl@latest/dist/react-intl.js):
   bundled dependencies (except `react`), browser or Node, warnings.
-- [__UMD prod__](https://unpkg.com/react-intl@latest/dist/react-intl.min.js):
+- [**UMD prod**](https://unpkg.com/react-intl@latest/dist/react-intl.min.js):
   minified, bundled dependencies (except `react`), browser or Node, no warnings.
-- [__UMD Locale Data__](https://unpkg.com/react-intl@latest/locale-data/):
+- [**UMD Locale Data**](https://unpkg.com/react-intl@latest/locale-data/):
   grouped by language, browser or Node, `index.js` contains all locales.
 
 **Note:** React Intl's locale data is in a directory at the package's root. This allows the locale data to be `import`-ed or `require`-d relative to the package. For example:
@@ -94,7 +94,7 @@ Whether you use the ES6, CommonJS, or UMD version of React Intl, they all provid
 - [`FormattedMessage`](Components.md#formattedmessage)
 - [`FormattedHTMLMessage`](Components.md#formattedhtmlmessage)
 
-**Note:** When using the UMD version of React Intl _without_ a module system, it will expect `react` to exist on the global variable: __`React`__, and put the above named exports on the global variable: __`ReactIntl`__.
+**Note:** When using the UMD version of React Intl _without_ a module system, it will expect `react` to exist on the global variable: **`React`**, and put the above named exports on the global variable: **`ReactIntl`**.
 
 ### Loading Locale Data
 
@@ -106,15 +106,15 @@ Because of these differences in how the locale data is organized, you'll need to
 
 #### Locale Data in Node.js
 
-When using React Intl in Node.js (same for the Intl.js polyfill), __all locale data will be loaded into memory.__ This makes it easier to write a universal/isomorphic React app with React Intl since you won't have to worry about dynamically loading locale data on the server.
+When using React Intl in Node.js (same for the Intl.js polyfill), **all locale data will be loaded into memory.** This makes it easier to write a universal/isomorphic React app with React Intl since you won't have to worry about dynamically loading locale data on the server.
 
 **Note:** As mentioned [above](#module-bundlers), when using Browserify/Webpack/Rollup to bundle React Intl for the browser, only basic English locale data will be included.
 
 #### Locale Data in Browsers
 
-When using React Intl in browsers, it will only contain locale data for basic English by default. __This means you'll need to either bundle locale data with your app code, or dynamically load a [locale data UMD module](#the-react-intl-package) based on the current user's locale.__
+When using React Intl in browsers, it will only contain locale data for basic English by default. **This means you'll need to either bundle locale data with your app code, or dynamically load a [locale data UMD module](#the-react-intl-package) based on the current user's locale.**
 
-React Intl provides an [__`addLocaleData` API__](./API.md#addlocaledata) which can be passed the contents of a locale data module and will register it in its locale data registry.
+React Intl provides an [**`addLocaleData` API**](./API.md#addlocaledata) which can be passed the contents of a locale data module and will register it in its locale data registry.
 
 If your app only supports a few languages, we recommend bundling React Intl's locale data for those languages with your app code as this approach is simpler. Here's an example of an app that supports English, French, and Spanish:
 
@@ -129,7 +129,7 @@ addLocaleData([...en, ...fr, ...es]);
 // ...
 ```
 
-If your app supports many locales, you can also dynamically load the locale data needed for the current user's language. This would involve outputting a different HTML document per users which includes a `<script>` to the correct locale data file. When loading a locale data file in a runtime _without_ a module system, it will be added to a global variable: __`ReactIntlLocaleData`__. Here's an example of loading React Intl and locale data for a French user:
+If your app supports many locales, you can also dynamically load the locale data needed for the current user's language. This would involve outputting a different HTML document per users which includes a `<script>` to the correct locale data file. When loading a locale data file in a runtime _without_ a module system, it will be added to a global variable: **`ReactIntlLocaleData`**. Here's an example of loading React Intl and locale data for a French user:
 
 ```html
 <!-- Load React and ReactDOM if they're not already on the page. -->
@@ -140,7 +140,7 @@ If your app supports many locales, you can also dynamically load the locale data
 <script src="https://unpkg.com/react-intl@latest/dist/react-intl.min.js"></script>
 <script src="https://unpkg.com/react-intl@latest/locale-data/fr.js"></script>
 <script>
-    ReactIntl.addLocaleData(ReactIntlLocaleData.fr);
+  ReactIntl.addLocaleData(ReactIntlLocaleData.fr);
 </script>
 ```
 
@@ -158,74 +158,71 @@ The most common usage is to wrap your root React component with `<IntlProvider>`
 
 ```js
 ReactDOM.render(
-    <IntlProvider
-        locale={usersLocale}
-        messages={translationsForUsersLocale}
-    >
-        <App/>
-    </IntlProvider>,
-    document.getElementById('container')
+  <IntlProvider locale={usersLocale} messages={translationsForUsersLocale}>
+    <App />
+  </IntlProvider>,
+  document.getElementById('container')
 );
 ```
 
-**See:** The [__`<IntlProvider>` docs__](./Components.md#intlprovider) for more details.
+**See:** The [**`<IntlProvider>` docs**](./Components.md#intlprovider) for more details.
 
 ### Formatting Data
 
-React Intl has two ways to format data, through [React components][Components] and its [API][API]. The components provide an idiomatic-React way of integrating internationalization into a React app, and the `<Formatted*>` components have [benefits](./Components.md#why-components) over always using the imperative API directly. The API should be used when your React component needs to format data to a string value where a React element is not suitable; e.g., a `title` or `aria` attribute, or for side-effect in `componentDidMount`.
+React Intl has two ways to format data, through [React components][components] and its [API][api]. The components provide an idiomatic-React way of integrating internationalization into a React app, and the `<Formatted*>` components have [benefits](./Components.md#why-components) over always using the imperative API directly. The API should be used when your React component needs to format data to a string value where a React element is not suitable; e.g., a `title` or `aria` attribute, or for side-effect in `componentDidMount`.
 
-React Intl's imperative API is accessed via [__`injectIntl`__](API.md#injectintl), a High-Order Component (HOC) factory. It will wrap the passed-in React component with another React component which provides the imperative formatting API into the wrapped component via its `props`. (This is similar to the connect-to-stores pattern found in many Flux implementations.)
+React Intl's imperative API is accessed via [**`injectIntl`**](API.md#injectintl), a High-Order Component (HOC) factory. It will wrap the passed-in React component with another React component which provides the imperative formatting API into the wrapped component via its `props`. (This is similar to the connect-to-stores pattern found in many Flux implementations.)
 
 Here's an example using `<IntlProvider>`, `<Formatted*>` components, and the imperative API to setup an i18n context and format data:
 
 ```js
 import React, {PropTypes} from 'react';
 import ReactDOM from 'react-dom';
-import {
-    injectIntl,
-    IntlProvider,
-    FormattedRelative,
-} from 'react-intl';
+import {injectIntl, IntlProvider, FormattedRelative} from 'react-intl';
 
 const PostDate = injectIntl(({date, intl}) => (
-    <span title={intl.formatDate(date)}>
-        <FormattedRelative value={date}/>
-    </span>
+  <span title={intl.formatDate(date)}>
+    <FormattedRelative value={date} />
+  </span>
 ));
 
 const App = ({post}) => (
-    <div>
-        <h1>{post.title}</h1>
-        <p><PostDate date={post.date}/></p>
-        <div>{post.body}</div>
-    </div>
+  <div>
+    <h1>{post.title}</h1>
+    <p>
+      <PostDate date={post.date} />
+    </p>
+    <div>{post.body}</div>
+  </div>
 );
 
 ReactDOM.render(
-    <IntlProvider locale={navigator.language}>
-        <App
-            post={{
-                title: 'Hello, World!',
-                date: new Date(1459913574887),
-                body: 'Amazing content.',
-            }}
-        />
-    </IntlProvider>,
-    document.getElementById('container')
+  <IntlProvider locale={navigator.language}>
+    <App
+      post={{
+        title: 'Hello, World!',
+        date: new Date(1459913574887),
+        body: 'Amazing content.',
+      }}
+    />
+  </IntlProvider>,
+  document.getElementById('container')
 );
 ```
+
 Assuming `navigator.language` is `"en-us"`:
+
 ```html
 <div>
-    <h1>Hello, World!</h1>
-    <p><span title="4/5/2016">yesterday</span></p>
-    <div>
-        Amazing content.
-    </div>
+  <h1>Hello, World!</h1>
+  <p><span title="4/5/2016">yesterday</span></p>
+  <div>
+    Amazing content.
+  </div>
 </div>
 ```
 
-**See:** The [__API docs__][API] and [__Component docs__][Components] for more details.
+**See:** The [**API docs**][api] and [**Component docs**][components] for more details.
 
 ## Core Concepts
 
@@ -247,8 +244,8 @@ There are several [**runnable example apps**](https://github.com/formatjs/react-
 There are a few API layers that React Intl provides and is built on. When using React Intl you'll be interacting with `Intl` built-ins, React Intl's API, and its React components:
 
 - [ECMAScript Internationalization API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
-- [React Intl API][API]
-- [React Intl Components][Components]
+- [React Intl API][api]
+- [React Intl Components][components]
 
-[API]: ./API.md
-[Components]: ./Components.md
+[api]: ./API.md
+[components]: ./Components.md

--- a/docs/IDE-plugins-&-Tools.md
+++ b/docs/IDE-plugins-&-Tools.md
@@ -1,4 +1,4 @@
-## IDE Plugins 
+## IDE Plugins
 
 In order to write application faster with `react-intl`, snippet plugins could be used for the IDE of your choice.
 Currently, there is a plugin available for `atom` and `nuclide`.
@@ -7,8 +7,6 @@ Currently, there is a plugin available for `atom` and `nuclide`.
 
 - [atom-react-intl-snippets](https://atom.io/packages/atom-react-intl-snippets)
 
-
 ## Editors
 
 - [BabelEdit](https://www.codeandweb.com/babeledit) - Translation file editor with syntax check
-

--- a/docs/Testing-with-React-Intl.md
+++ b/docs/Testing-with-React-Intl.md
@@ -56,13 +56,13 @@ The following examples will assume `mocha`, `expect`, and `expect-jsx` test fram
 import React from 'react';
 import {FormattedDate} from 'react-intl';
 
-const ShortDate = (props) => (
-    <FormattedDate
-        value={props.date}
-        year='numeric'
-        month='short'
-        day='2-digit'
-    />
+const ShortDate = props => (
+  <FormattedDate
+    value={props.date}
+    year="numeric"
+    month="short"
+    day="2-digit"
+  />
 );
 
 export default ShortDate;
@@ -80,21 +80,16 @@ import ShortDate from '../short-date';
 
 expect.extend(expectJSX);
 
-describe('<ShortDate>', function () {
-    it('renders', function () {
-        const renderer = createRenderer();
-        const date = new Date();
+describe('<ShortDate>', function() {
+  it('renders', function() {
+    const renderer = createRenderer();
+    const date = new Date();
 
-        renderer.render(<ShortDate date={date}/>);
-        expect(renderer.getRenderOutput()).toEqualJSX(
-            <FormattedDate
-                value={date}
-                year='numeric'
-                month='short'
-                day='2-digit'
-            />
-        );
-    });
+    renderer.render(<ShortDate date={date} />);
+    expect(renderer.getRenderOutput()).toEqualJSX(
+      <FormattedDate value={date} year="numeric" month="short" day="2-digit" />
+    );
+  });
 });
 ```
 
@@ -104,10 +99,10 @@ describe('<ShortDate>', function () {
 import React, {Component} from 'react';
 import {injectIntl, FormattedRelative} from 'react-intl';
 
-const RelativeDate = (props) => (
-    <span title={props.intl.formatDate(props.value)}>
-        <FormattedRelative value={props.value}/>
-    </span>
+const RelativeDate = props => (
+  <span title={props.intl.formatDate(props.value)}>
+    <FormattedRelative value={props.value} />
+  </span>
 );
 
 // Using `injectIntl()` to make React Intl's imperative API available to format
@@ -126,45 +121,37 @@ import expect from 'expect';
 import expectJSX from 'expect-jsx';
 import React from 'react';
 import {createRenderer} from 'react-addons-test-utils';
-import {
-    IntlProvider,
-    FormattedRelative,
-} from 'react-intl';
+import {IntlProvider, FormattedRelative} from 'react-intl';
 import RelativeDate from '../relative-date';
 
 expect.extend(expectJSX);
 
-describe('<RelativeDate>', function () {
-    it('renders', function () {
-        const renderer = createRenderer();
-        const date = new Date();
+describe('<RelativeDate>', function() {
+  it('renders', function() {
+    const renderer = createRenderer();
+    const date = new Date();
 
-        // Construct a new `IntlProvider` instance by passing `props` and
-        // `context` as React would, then call `getChildContext()` to get the
-        // React Intl API, complete with the `format*()` functions.
-        const intlProvider = new IntlProvider({locale: 'en'}, {});
-        const {intl} = intlProvider.getChildContext();
+    // Construct a new `IntlProvider` instance by passing `props` and
+    // `context` as React would, then call `getChildContext()` to get the
+    // React Intl API, complete with the `format*()` functions.
+    const intlProvider = new IntlProvider({locale: 'en'}, {});
+    const {intl} = intlProvider.getChildContext();
 
-        // Access the underlying `<RelativeDate>` component from the wrapper
-        // component returned from calling `injectIntl()`, and create an
-        // element making sure to pass the `intl` API as a prop to the to
-        // simulate what `injectIntl()` does.
-        renderer.render(
-            <RelativeDate.WrappedComponent
-                date={date}
-                intl={intl}
-            />
-        );
+    // Access the underlying `<RelativeDate>` component from the wrapper
+    // component returned from calling `injectIntl()`, and create an
+    // element making sure to pass the `intl` API as a prop to the to
+    // simulate what `injectIntl()` does.
+    renderer.render(<RelativeDate.WrappedComponent date={date} intl={intl} />);
 
-        // Use the `intl` API directly to format the date for the expected
-        // output. This is important when testing absolute dates since their
-        // values will differ based on the timezone where the test is running.
-        expect(renderer.getRenderOutput()).toEqualJSX(
-            <span title={intl.formatDate(date)}>
-                <FormattedRelative value={date}/>
-            </span>
-        );
-    });
+    // Use the `intl` API directly to format the date for the expected
+    // output. This is important when testing absolute dates since their
+    // values will differ based on the timezone where the test is running.
+    expect(renderer.getRenderOutput()).toEqualJSX(
+      <span title={intl.formatDate(date)}>
+        <FormattedRelative value={date} />
+      </span>
+    );
+  });
 });
 ```
 
@@ -173,7 +160,11 @@ describe('<RelativeDate>', function () {
 If you use the DOM in your tests, you need to supply the `IntlProvider` context to your components using composition:
 
 ```js
-let element = ReactTestUtils.renderIntoDocument(<IntlProvider><MyComponent /></IntlProvider>);
+let element = ReactTestUtils.renderIntoDocument(
+  <IntlProvider>
+    <MyComponent />
+  </IntlProvider>
+);
 ```
 
 However this means that the `element` reference is now pointing to the `IntlProvider` instead of your component. To retrieve a reference to your wrapped component, you can use "refs" with these changes to the code:
@@ -193,7 +184,9 @@ In your test, add a "ref" to extract the reference to your tested component:
 ```js
 let element;
 let root = ReactTestUtils.renderIntoDocument(
-  <IntlProvider><MyComponent ref={(c) => element = c.refs.wrappedInstance} /></IntlProvider>
+  <IntlProvider>
+    <MyComponent ref={c => (element = c.refs.wrappedInstance)} />
+  </IntlProvider>
 );
 ```
 
@@ -213,7 +206,9 @@ function renderWithIntl(element) {
 
   ReactTestUtils.renderIntoDocument(
     <IntlProvider>
-      {React.cloneElement(element, {ref: (c) => instance = c.refs.wrappedInstance})}
+      {React.cloneElement(element, {
+        ref: c => (instance = c.refs.wrappedInstance),
+      })}
     </IntlProvider>
   );
 
@@ -232,7 +227,7 @@ element.myClassFn();
 
 Testing with Enzyme works in a similar fashion as written above. Your `mount()`ed and `shallow()`ed components will need access to the `intl` context. Below is a helper function which you can import and use to mount your components which make use of any of React-Intl's library (either `<Formatted* />` components or `format*()` methods through `injectIntl`).
 
-### Helper function 
+### Helper function
 
 ```js
 /**
@@ -243,42 +238,39 @@ Testing with Enzyme works in a similar fashion as written above. Your `mount()`e
  */
 
 import React from 'react';
-import { IntlProvider, intlShape } from 'react-intl';
-import { mount, shallow } from 'enzyme';
+import {IntlProvider, intlShape} from 'react-intl';
+import {mount, shallow} from 'enzyme';
 
 // You can pass your messages to the IntlProvider. Optional: remove if unneeded.
 const messages = require('../locales/en'); // en.json
 
 // Create the IntlProvider to retrieve context for wrapping around.
-const intlProvider = new IntlProvider({ locale: 'en', messages }, {});
-const { intl } = intlProvider.getChildContext();
+const intlProvider = new IntlProvider({locale: 'en', messages}, {});
+const {intl} = intlProvider.getChildContext();
 
 /**
  * When using React-Intl `injectIntl` on components, props.intl is required.
  */
 function nodeWithIntlProp(node) {
-    return React.cloneElement(node, { intl });
+  return React.cloneElement(node, {intl});
 }
 
-export function shallowWithIntl(node, { context, ...additionalOptions } = {}) {
-    return shallow(
-        nodeWithIntlProp(node),
-        {
-            context: Object.assign({}, context, {intl}),
-            ...additionalOptions,
-        }
-    );
+export function shallowWithIntl(node, {context, ...additionalOptions} = {}) {
+  return shallow(nodeWithIntlProp(node), {
+    context: Object.assign({}, context, {intl}),
+    ...additionalOptions,
+  });
 }
 
-export function mountWithIntl(node, { context, childContextTypes, ...additionalOptions } = {}) {
-    return mount(
-        nodeWithIntlProp(node),
-        {
-            context: Object.assign({}, context, {intl}),
-            childContextTypes: Object.assign({}, { intl: intlShape }, childContextTypes),
-            ...additionalOptions,
-        }
-    );
+export function mountWithIntl(
+  node,
+  {context, childContextTypes, ...additionalOptions} = {}
+) {
+  return mount(nodeWithIntlProp(node), {
+    context: Object.assign({}, context, {intl}),
+    childContextTypes: Object.assign({}, {intl: intlShape}, childContextTypes),
+    ...additionalOptions,
+  });
 }
 ```
 
@@ -289,13 +281,11 @@ Create a file with the above helper in e.g. `helpers/intl-enzyme-test-helper.js`
 ```js
 // intl-enzyme-test-helper.js
 
-import { mountWithIntl } from 'helpers/intl-enzyme-test-helper.js';
+import {mountWithIntl} from 'helpers/intl-enzyme-test-helper.js';
 
-const wrapper = mountWithIntl(
-  <CustomComponent />
-);
+const wrapper = mountWithIntl(<CustomComponent />);
 
-expect(wrapper.state('foo')).to.equal('bar');    // OK
+expect(wrapper.state('foo')).to.equal('bar'); // OK
 expect(wrapper.text()).to.equal('Hello World!'); // OK
 ```
 
@@ -314,15 +304,11 @@ Snapshot testing is a new feature of Jest that automatically generates text snap
 ```js
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { IntlProvider } from 'react-intl';
+import {IntlProvider} from 'react-intl';
 
-const createComponentWithIntl = (children, props = { locale: 'en' }) => {
-  return renderer.create(
-    <IntlProvider {...props}>
-      {children}
-    </IntlProvider>
-  );
-}
+const createComponentWithIntl = (children, props = {locale: 'en'}) => {
+  return renderer.create(<IntlProvider {...props}>{children}</IntlProvider>);
+};
 
 export default createComponentWithIntl;
 ```
@@ -335,7 +321,7 @@ import createComponentWithIntl from '../../utils/createComponentWithIntl';
 import AppMain from '../AppMain';
 
 test('app main should be rendered', () => {
-  const component = createComponentWithIntl(<AppMain/>);
+  const component = createComponentWithIntl(<AppMain />);
 
   let tree = component.toJSON();
 
@@ -353,7 +339,7 @@ You can find runnable example [here](https://github.com/formatjs/react-intl/tree
 
 #### Jest mock
 
-Following mock is simplified version of injectIntl, formatMessage just places defaultMessage. Should be placed in the root of your project (where node_modules reside) under __mocks__ subfolder:
+Following mock is simplified version of injectIntl, formatMessage just places defaultMessage. Should be placed in the root of your project (where node_modules reside) under **mocks** subfolder:
 
 ```js
 // ./__mocks__/react-intl.js
@@ -362,14 +348,12 @@ const Intl = jest.genMockFromModule('react-intl');
 
 // Here goes intl context injected into component, feel free to extend
 const intl = {
-  formatMessage: ({defaultMessage}) => defaultMessage
+  formatMessage: ({defaultMessage}) => defaultMessage,
 };
 
-Intl.injectIntl = (Node) => {
+Intl.injectIntl = Node => {
   const renderWrapped = props => <Node {...props} intl={intl} />;
-  renderWrapped.displayName = Node.displayName
-    || Node.name
-    || 'Component'
+  renderWrapped.displayName = Node.displayName || Node.name || 'Component';
   return renderWrapped;
 };
 
@@ -382,13 +366,13 @@ Jest will automatically mock react-intl, so no any extra implementation is neede
 
 ```js
 import React from 'react';
-import { shallow } from 'enzyme';
+import {shallow} from 'enzyme';
 import AppMain from '../AppMain';
 
 test('app main should be rendered', () => {
-  const wrapper = shallow(<AppMain/>);
+  const wrapper = shallow(<AppMain />);
   expect(wrapper).toMatchSnapshot();
-})
+});
 ```
 
 ### DOM Testing
@@ -410,22 +394,22 @@ You can check the [docs](https://testing-library.com/docs/example-react-intl).
 And can find a functional example [here](https://github.com/testing-library/react-testing-library/blob/master/examples/__tests__/react-intl.js)
 
 ```jsx
-import React from 'react'
-import 'jest-dom/extend-expect'
-import { render, cleanup, getByTestId } from 'react-testing-library'
-import { IntlProvider, FormattedDate } from 'react-intl'
-import IntlPolyfill from 'intl'
-import 'intl/locale-data/jsonp/pt'
+import React from 'react';
+import 'jest-dom/extend-expect';
+import {render, cleanup, getByTestId} from 'react-testing-library';
+import {IntlProvider, FormattedDate} from 'react-intl';
+import IntlPolyfill from 'intl';
+import 'intl/locale-data/jsonp/pt';
 
 const setupTests = () => {
   // https://formatjs.io/guides/runtime-environments/#server
   if (global.Intl) {
-    Intl.NumberFormat = IntlPolyfill.NumberFormat
-    Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat
+    Intl.NumberFormat = IntlPolyfill.NumberFormat;
+    Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
   } else {
-    global.Intl = IntlPolyfill
+    global.Intl = IntlPolyfill;
   }
-}
+};
 
 const FormatDateView = () => {
   return (
@@ -438,18 +422,20 @@ const FormatDateView = () => {
         year="numeric"
       />
     </div>
-  )
-}
+  );
+};
 
 const renderWithReactIntl = component => {
-  return render(<IntlProvider locale="pt">{component}</IntlProvider>)
-}
+  return render(<IntlProvider locale="pt">{component}</IntlProvider>);
+};
 
-setupTests()
-afterEach(cleanup)
+setupTests();
+afterEach(cleanup);
 
 test('it should render FormattedDate and have a formated pt date', () => {
-  const { container } = renderWithReactIntl(<FormatDateView />)
-  expect(getByTestId(container, 'date-display')).toHaveTextContent('11/03/2019')
-})
+  const {container} = renderWithReactIntl(<FormatDateView />);
+  expect(getByTestId(container, 'date-display')).toHaveTextContent(
+    '11/03/2019'
+  );
+});
 ```

--- a/docs/Upgrade-Guide.md
+++ b/docs/Upgrade-Guide.md
@@ -18,65 +18,65 @@ With the update to React `>= 16.3` we got the option to use the new `React.forwa
 When `forwardRef` is set to true, you can now simply pretend the HOC wasn't there at all.
 
 Intl v2:
+
 ```js
-import React from 'react'
-import { injectIntl } from 'react-intl'
+import React from 'react';
+import {injectIntl} from 'react-intl';
 
 class MyComponent extends React.Component {
-  doSomething = () => console.log(this.state || null)
+  doSomething = () => console.log(this.state || null);
 
-  render () {
-    return (
-      <div>Hello World</div>
-    )
+  render() {
+    return <div>Hello World</div>;
   }
 }
 
-export default injectIntl(MyComponent, { withRef: true })
+export default injectIntl(MyComponent, {withRef: true});
 
 // somewhere else
 class Parent extends React.Component {
-  componentDidMount () {
-    this.myComponentRef.getWrappedInstance().doSomething()
+  componentDidMount() {
+    this.myComponentRef.getWrappedInstance().doSomething();
   }
 
-  render () {
+  render() {
     return (
-      <MyComponent ref={(ref) => {this.myComponentRef = ref}} />
-    )
+      <MyComponent
+        ref={ref => {
+          this.myComponentRef = ref;
+        }}
+      />
+    );
   }
 }
 ```
 
 Intl v3:
+
 ```js
-import React from 'react'
-import { injectIntl } from 'react-intl'
+import React from 'react';
+import {injectIntl} from 'react-intl';
 
 class MyComponent extends React.Component {
-  doSomething = () => console.log(this.state || null)
+  doSomething = () => console.log(this.state || null);
 
-  render () {
-    return (
-      <div>Hello World</div>
-    )
+  render() {
+    return <div>Hello World</div>;
   }
 }
 
-export default injectIntl(MyComponent, { forwardRef: true })
+export default injectIntl(MyComponent, {forwardRef: true});
 
 // somewhere else
 class Parent extends React.Component {
-  myComponentRef = React.createRef()
+  myComponentRef = React.createRef();
 
-  componentDidMount () {
-    this.myComponentRef.doSomething() // no need to call getWrappedInstance()
+  componentDidMount() {
+    this.myComponentRef.doSomething(); // no need to call getWrappedInstance()
   }
 
-  render () {
-    return (
-      <MyComponent ref={this.myComponentRef} />
-    )
+  render() {
+    return <MyComponent ref={this.myComponentRef} />;
   }
 }
 ```
@@ -87,20 +87,20 @@ This v3 release also supports the latest React hook API for user with React `>= 
 
 ```js
 // injectIntl
-import { injectIntl } from 'react-intl'
+import {injectIntl} from 'react-intl';
 
-const MyComponentWithHOC = injectIntl(({ intl, ...props }) => {
+const MyComponentWithHOC = injectIntl(({intl, ...props}) => {
   // do something
-})
+});
 
 // useIntl
-import { useIntl } from 'react-intl'
+import {useIntl} from 'react-intl';
 
-const MyComponentWithHook = (props) => {
+const MyComponentWithHook = props => {
   const intl = useIntl();
 
   // do something
-}
+};
 ```
 
 To keep the API surface clean and simple, we only provide `useIntl` hook in the package. If preferable, user can wrap this built-in hook to make customized hook like `useFormatMessage` easily. Please visit React's official website for more general [introduction on React hooks](https://reactjs.org/docs/hooks-intro.html).
@@ -142,22 +142,24 @@ This assumes a locale data `<script>` is added based on the request; e.g., for F
 ```
 
 **Using `<script src="react-intl/dist/react-intl.js>`:**
+
 ```js
 if ('ReactIntl' in window && 'ReactIntlLocaleData' in window) {
-    Object.keys(ReactIntlLocaleData).forEach((lang) => {
-        ReactIntl.addLocaleData(ReactIntlLocaleData[lang]);
-    });
+  Object.keys(ReactIntlLocaleData).forEach(lang => {
+    ReactIntl.addLocaleData(ReactIntlLocaleData[lang]);
+  });
 }
 ```
 
 **Using Browserify/Webpack to Load React Intl:**
+
 ```js
 import {addLocaleData} from 'react-intl';
 
 if ('ReactIntlLocaleData' in window) {
-    Object.keys(ReactIntlLocaleData).forEach((lang) => {
-        addLocaleData(ReactIntlLocaleData[lang]);
-    });
+  Object.keys(ReactIntlLocaleData).forEach(lang => {
+    addLocaleData(ReactIntlLocaleData[lang]);
+  });
 }
 ```
 
@@ -176,10 +178,10 @@ import ReactDOM from 'react-dom';
 import {IntlProvider} from 'react-intl';
 
 ReactDOM.render(
-    <IntlProvider locale='en'>
-        <App/>
-    </IntlProvider>,
-    document.getElementById('container')
+  <IntlProvider locale="en">
+    <App />
+  </IntlProvider>,
+  document.getElementById('container')
 );
 ```
 
@@ -193,34 +195,31 @@ Here's an example of a custom `<RelativeTime>` stateless component which uses `i
 
 ```js
 import React from 'react';
-import {
-    injectIntl,
-    FormattedRelative,
-} from 'react-intl';
+import {injectIntl, FormattedRelative} from 'react-intl';
 
-const to2Digits = (num) => `${num < 10 ? `0${num}` : num}`;
+const to2Digits = num => `${num < 10 ? `0${num}` : num}`;
 
 const RelativeTime = ({date, intl}) => {
-    date = new Date(date);
+  date = new Date(date);
 
-    let year  = date.getFullYear();
-    let month = date.getMonth() + 1;
-    let day   = date.getDate();
+  let year = date.getFullYear();
+  let month = date.getMonth() + 1;
+  let day = date.getDate();
 
-    let formattedDate = intl.formatDate(date, {
-        year : 'long',
-        month: 'numeric',
-        day  : 'numeric'
-    });
+  let formattedDate = intl.formatDate(date, {
+    year: 'long',
+    month: 'numeric',
+    day: 'numeric',
+  });
 
-    return (
-        <time
-            dateTime={`${year}-${to2Digits(month)}-${to2Digits(day)}`}
-            title={formattedDate}
-        >
-            <FormattedRelative value={date}/>
-        </time>
-    );
+  return (
+    <time
+      dateTime={`${year}-${to2Digits(month)}-${to2Digits(day)}`}
+      title={formattedDate}
+    >
+      <FormattedRelative value={date} />
+    </time>
+  );
 };
 
 export default injectIntl(RelativeTime);
@@ -248,18 +247,18 @@ Apps using a nested `messages` object structure could use the following function
 
 ```js
 function flattenMessages(nestedMessages, prefix = '') {
-    return Object.keys(nestedMessages).reduce((messages, key) => {
-        let value       = nestedMessages[key];
-        let prefixedKey = prefix ? `${prefix}.${key}` : key;
+  return Object.keys(nestedMessages).reduce((messages, key) => {
+    let value = nestedMessages[key];
+    let prefixedKey = prefix ? `${prefix}.${key}` : key;
 
-        if (typeof value === 'string') {
-            messages[prefixedKey] = value;
-        } else {
-            Object.assign(messages, flattenMessages(value, prefixedKey));
-        }
+    if (typeof value === 'string') {
+      messages[prefixedKey] = value;
+    } else {
+      Object.assign(messages, flattenMessages(value, prefixedKey));
+    }
 
-        return messages;
-    }, {});
+    return messages;
+  }, {});
 }
 
 let messages = flattenMessages(nestedMessages);
@@ -274,13 +273,17 @@ The `getIntlMessage()` method that was provided by the `IntlMixin` has been remo
 All calls to `getIntlMessage()` need to be replaced with a Message Descriptor.
 
 **Replace:**
+
 ```js
-this.getIntlMessage('some.message.id')
+this.getIntlMessage('some.message.id');
 ```
 
 **With:**
+
 ```js
-{id: 'some.message.id'}
+{
+  id: 'some.message.id';
+}
 ```
 
 #### Update `formatMessage()` Calls
@@ -288,11 +291,16 @@ this.getIntlMessage('some.message.id')
 A typical pattern when calling `formatMessage()` is to nest a call to `getIntlMessage()`. These can be easily updated:
 
 **1.0:**
+
 ```js
-let message = this.formatMessage(this.getIntlMessage('some.message.id'), values);
+let message = this.formatMessage(
+  this.getIntlMessage('some.message.id'),
+  values
+);
 ```
 
 **2.0:**
+
 ```js
 let message = this.props.intl.formatMessage({id: 'some.message.id'}, values);
 ```
@@ -308,19 +316,15 @@ The new `values` prop groups all of the message's placeholder values together in
 The following example shows up to update a `<FormattedMessage>` instance to use the new props and remove the call to `getIntlMessage()`:
 
 **1.0:**
+
 ```js
-<FormattedMessage
-    message={this.getIntlMessage('greeting')}
-    name='Eric'
-/>
+<FormattedMessage message={this.getIntlMessage('greeting')} name="Eric" />
 ```
 
 **2.0:**
+
 ```js
-<FormattedMessage
-    id='greeting'
-    values={{name: 'Eric'}}
-/>
+<FormattedMessage id="greeting" values={{name: 'Eric'}} />
 ```
 
 ### Update How Relative Times are Formatted
@@ -332,13 +336,15 @@ Minor changes have been made to how the "now" reference time is specified when f
 A new feature has been added to [`<FormattedRelative>`](Components#formattedrelative) instances in React Intl v2, they now "tick" and stay up to date. Since time moves forward, it was confusing to have a prop named `now`, so it has been renamed to `initialNow`. Any `<FormattedRelative>` instances that use `now` should update to prop name to `initialNow`:
 
 **1.0:**
+
 ```js
-<FormattedRelative value={date} now={otherDate}/>
+<FormattedRelative value={date} now={otherDate} />
 ```
 
 **2.0:**
+
 ```js
-<FormattedRelative value={date} initialNow={otherDate}/>
+<FormattedRelative value={date} initialNow={otherDate} />
 ```
 
 **Note:** The [`<IntlProvider>`](Components#intlprovider) component also has a `initialNow` prop which can be assigned a value to stabilize the "now" reference time for _all_ [`<FormattedRelative>`](Components#formattedrelative) instances. This is useful for universal/isomorphic apps to proper React checksums between the server and client initial render.
@@ -348,15 +354,17 @@ A new feature has been added to [`<FormattedRelative>`](Components#formattedrela
 The signature of the `formatRelative()` function has been aligned with the other `format*()` functions and in React Intl v2, it only accepts two arguments: `value` and `options`. To specify a "now" reference time, add it to the `options` argument, and remove the third `formatOptions` argument:
 
 **1.0:**
+
 ```js
 let relative = this.formatRelative(date, {units: 'hour'}, {now: otherDate});
 ```
 
 **2.0:**
+
 ```js
 let relative = this.props.intl.formatRelative(date, {
-    units: 'hour',
-    now  : otherDate
+  units: 'hour',
+  now: otherDate,
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -132,8 +132,8 @@
     "watchify": "^3.7.0"
   },
   "scripts": {
-    "format": "prettier --check *.js scripts/*.js src/{*.js,**/*.js}",
-    "format:fix": "prettier --write *.js scripts/*.js src/{*.js,**/*.js}",
+    "format": "prettier --check *.js scripts/*.js src/{*.js,**/*.js} *.md **/*.md",
+    "format:fix": "prettier --write *.js scripts/*.js src/{*.js,**/*.js} *.md **/*.md",
     "clean": "rimraf src/en.js coverage/ dist/ lib/ test/renderer.js",
     "build:lib": "rollup -c rollup.config.lib.js",
     "build:dist:dev": "cross-env NODE_ENV=development rollup -c rollup.config.dist.js",


### PR DESCRIPTION
It checks and fix format Markdown docs via `yarn run format`/`yarn run format:fix` since prettier supports Markdown syntax.