### PR TITLE
chore: rm some custom utils impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ src/en.js
 
 # IntelliJ
 .idea/
+
+# VS Code
+.vscode

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "singleQuote": true,
   "trailingComma": "es5",
-  "bracketSpacing": false
+  "bracketSpacing": false,
+  "endOfLine": "lf"
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "intl-messageformat": "^4.0.0",
     "intl-relativeformat": "^6.1.0",
     "invariant": "^2.1.1",
-    "react-display-name": "^0.2.4",
     "react-is": "^16.3.1",
     "shallow-equal": "^1.1.0"
   },
@@ -106,7 +105,6 @@
     "eslint-plugin-react": "^7.0.1",
     "expect": "^1.9.0",
     "express": "^4.13.3",
-    "formatjs-extract-cldr-data": "^6.0.0",
     "full-icu": "^1.3.0",
     "glob": "^7.0.0",
     "intl": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -65,12 +65,13 @@
   "dependencies": {
     "hoist-non-react-statics": "^3.3.0",
     "intl-format-cache": "^3.0.0",
+    "intl-locales-supported": "^1.0.10",
     "intl-messageformat": "^4.0.0",
     "intl-relativeformat": "^6.1.0",
-    "intl-locales-supported": "^1.0.10",
     "invariant": "^2.1.1",
     "react-display-name": "^0.2.4",
-    "react-is": "^16.3.1"
+    "react-is": "^16.3.1",
+    "shallow-equal": "^1.1.0"
   },
   "peerDependencies": {
     "prop-types": "^15.5.4",
@@ -86,6 +87,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
+    "@formatjs/intl-relativetimeformat": "^1.0.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^7.1.1",
     "babel-jest": "^23.6.0",
@@ -110,7 +112,6 @@
     "intl": "^1.2.1",
     "intl-messageformat-parser": "^1.2.0",
     "intl-pluralrules": "^1.0.1",
-    "@formatjs/intl-relativetimeformat": "^1.0.0",
     "jest": "^23.6.0",
     "mkdirp": "^0.5.1",
     "prettier": "^1.6.1",

--- a/src/components/date.js
+++ b/src/components/date.js
@@ -4,13 +4,13 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import withIntl from './withIntl';
 import {intlShape, dateTimeFormatPropTypes} from '../types';
-import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
+import {invariantIntlContext} from '../utils';
 
-class FormattedDate extends Component {
+class FormattedDate extends PureComponent {
   static displayName = 'FormattedDate';
 
   static propTypes = {
@@ -24,10 +24,6 @@ class FormattedDate extends Component {
   constructor(props) {
     super(props);
     invariantIntlContext(props);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shouldIntlComponentUpdate(this, nextProps, nextState);
   }
 
   render() {

--- a/src/components/date.js
+++ b/src/components/date.js
@@ -4,40 +4,35 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import React, {PureComponent} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import withIntl from './withIntl';
 import {intlShape, dateTimeFormatPropTypes} from '../types';
-import {invariantIntlContext} from '../utils';
 
-class FormattedDate extends PureComponent {
-  static displayName = 'FormattedDate';
+function FormattedDate(props) {
+  const {
+    value,
+    children,
+    intl: {formatDate, textComponent: Text},
+  } = props;
 
-  static propTypes = {
-    ...dateTimeFormatPropTypes,
-    intl: intlShape,
-    value: PropTypes.any.isRequired,
-    format: PropTypes.string,
-    children: PropTypes.func,
-  };
+  let formattedDate = formatDate(value, props);
 
-  constructor(props) {
-    super(props);
-    invariantIntlContext(props);
+  if (typeof children === 'function') {
+    return children(formattedDate);
   }
 
-  render() {
-    const {formatDate, textComponent: Text} = this.props.intl;
-    const {value, children} = this.props;
-
-    let formattedDate = formatDate(value, this.props);
-
-    if (typeof children === 'function') {
-      return children(formattedDate);
-    }
-
-    return <Text>{formattedDate}</Text>;
-  }
+  return <Text>{formattedDate}</Text>;
 }
+
+FormattedDate.propTypes = {
+  ...dateTimeFormatPropTypes,
+  intl: intlShape,
+  value: PropTypes.any.isRequired,
+  format: PropTypes.string,
+  children: PropTypes.func,
+};
+
+FormattedDate.displayName = 'FormattedDate';
 
 export default withIntl(FormattedDate);

--- a/src/components/html-message.js
+++ b/src/components/html-message.js
@@ -9,8 +9,6 @@ import withIntl from './withIntl';
 import {BaseFormattedMessage} from './message';
 
 class FormattedHTMLMessage extends BaseFormattedMessage {
-  static displayName = 'FormattedHTMLMessage';
-
   render() {
     const {formatHTMLMessage, textComponent: Text} = this.props.intl;
 

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -42,13 +42,6 @@ class FormattedMessage extends PureComponent {
     values: {},
   };
 
-  constructor(props) {
-    super(props);
-    if (!props.defaultMessage) {
-      invariantIntlContext(props);
-    }
-  }
-
   shouldComponentUpdate(nextProps, nextState) {
     const {values} = this.props;
     const {values: nextValues} = nextProps;

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -4,17 +4,14 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import {Component, createElement, isValidElement} from 'react';
+import {PureComponent, createElement, isValidElement} from 'react';
 import PropTypes from 'prop-types';
 import withIntl from './withIntl';
 import IntlMessageFormat from 'intl-messageformat';
 import memoizeIntlConstructor from 'intl-format-cache';
 import {intlShape, messageDescriptorPropTypes} from '../types';
-import {
-  invariantIntlContext,
-  shallowEquals,
-  shouldIntlComponentUpdate,
-} from '../utils';
+import {invariantIntlContext} from '../utils';
+import shallowEquals from 'shallow-equal/objects';
 import {formatMessage as baseFormatMessage} from '../format';
 
 const defaultFormatMessage = (descriptor, values) => {
@@ -32,7 +29,7 @@ const defaultFormatMessage = (descriptor, values) => {
   );
 };
 
-class FormattedMessage extends Component {
+class FormattedMessage extends PureComponent {
   static displayName = 'FormattedMessage';
 
   static propTypes = {
@@ -70,7 +67,10 @@ class FormattedMessage extends Component {
       values,
     };
 
-    return shouldIntlComponentUpdate(this, nextPropsToCheck, nextState);
+    return (
+      !shallowEquals(this.props, nextPropsToCheck) ||
+      !shallowEquals(this.state, nextState)
+    );
   }
 
   render() {

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -4,15 +4,15 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import {PureComponent, createElement, isValidElement} from 'react';
+import {Component, createElement, isValidElement} from 'react';
 import PropTypes from 'prop-types';
 import withIntl from './withIntl';
 import IntlMessageFormat from 'intl-messageformat';
 import memoizeIntlConstructor from 'intl-format-cache';
 import {intlShape, messageDescriptorPropTypes} from '../types';
-import {invariantIntlContext} from '../utils';
 import shallowEquals from 'shallow-equal/objects';
 import {formatMessage as baseFormatMessage} from '../format';
+import {invariantIntlContext} from '../utils';
 
 const defaultFormatMessage = (descriptor, values) => {
   if (process.env.NODE_ENV !== 'production') {
@@ -29,7 +29,7 @@ const defaultFormatMessage = (descriptor, values) => {
   );
 };
 
-class FormattedMessage extends PureComponent {
+class FormattedMessage extends Component {
   static propTypes = {
     ...messageDescriptorPropTypes,
     intl: intlShape,
@@ -41,6 +41,13 @@ class FormattedMessage extends PureComponent {
   static defaultProps = {
     values: {},
   };
+
+  constructor(props) {
+    super(props);
+    if (!props.defaultMessage) {
+      invariantIntlContext(props);
+    }
+  }
 
   shouldComponentUpdate(nextProps, nextState) {
     const {values} = this.props;
@@ -148,4 +155,4 @@ class FormattedMessage extends PureComponent {
 
 export const BaseFormattedMessage = FormattedMessage;
 
-export default withIntl(FormattedMessage);
+export default withIntl(FormattedMessage, {enforceContext: false});

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -30,8 +30,6 @@ const defaultFormatMessage = (descriptor, values) => {
 };
 
 class FormattedMessage extends PureComponent {
-  static displayName = 'FormattedMessage';
-
   static propTypes = {
     ...messageDescriptorPropTypes,
     intl: intlShape,

--- a/src/components/number.js
+++ b/src/components/number.js
@@ -4,40 +4,35 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import React, {PureComponent} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import withIntl from './withIntl';
 import {intlShape, numberFormatPropTypes} from '../types';
-import {invariantIntlContext} from '../utils';
 
-class FormattedNumber extends PureComponent {
-  static displayName = 'FormattedNumber';
+function FormattedNumber(props) {
+  const {
+    value,
+    children,
+    intl: {formatNumber, textComponent: Text},
+  } = props;
 
-  static propTypes = {
-    ...numberFormatPropTypes,
-    intl: intlShape,
-    value: PropTypes.any.isRequired,
-    format: PropTypes.string,
-    children: PropTypes.func,
-  };
+  let formattedNumber = formatNumber(value, props);
 
-  constructor(props) {
-    super(props);
-    invariantIntlContext(props);
+  if (typeof children === 'function') {
+    return children(formattedNumber);
   }
 
-  render() {
-    const {formatNumber, textComponent: Text} = this.props.intl;
-    const {value, children} = this.props;
-
-    let formattedNumber = formatNumber(value, this.props);
-
-    if (typeof children === 'function') {
-      return children(formattedNumber);
-    }
-
-    return <Text>{formattedNumber}</Text>;
-  }
+  return <Text>{formattedNumber}</Text>;
 }
+
+FormattedNumber.propTypes = {
+  ...numberFormatPropTypes,
+  intl: intlShape,
+  value: PropTypes.any.isRequired,
+  format: PropTypes.string,
+  children: PropTypes.func,
+};
+
+FormattedNumber.displayName = 'FormattedNumber';
 
 export default withIntl(FormattedNumber);

--- a/src/components/number.js
+++ b/src/components/number.js
@@ -4,13 +4,13 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import withIntl from './withIntl';
 import {intlShape, numberFormatPropTypes} from '../types';
-import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
+import {invariantIntlContext} from '../utils';
 
-class FormattedNumber extends Component {
+class FormattedNumber extends PureComponent {
   static displayName = 'FormattedNumber';
 
   static propTypes = {
@@ -24,10 +24,6 @@ class FormattedNumber extends Component {
   constructor(props) {
     super(props);
     invariantIntlContext(props);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shouldIntlComponentUpdate(this, nextProps, nextState);
   }
 
   render() {

--- a/src/components/plural.js
+++ b/src/components/plural.js
@@ -4,13 +4,13 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import withIntl from './withIntl';
 import {intlShape, pluralFormatPropTypes} from '../types';
-import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
+import {invariantIntlContext} from '../utils';
 
-class FormattedPlural extends Component {
+class FormattedPlural extends PureComponent {
   static displayName = 'FormattedPlural';
 
   static propTypes = {
@@ -35,10 +35,6 @@ class FormattedPlural extends Component {
   constructor(props) {
     super(props);
     invariantIntlContext(props);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shouldIntlComponentUpdate(this, nextProps, nextState);
   }
 
   render() {

--- a/src/components/plural.js
+++ b/src/components/plural.js
@@ -4,52 +4,48 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import React, {PureComponent} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import withIntl from './withIntl';
 import {intlShape, pluralFormatPropTypes} from '../types';
-import {invariantIntlContext} from '../utils';
 
-class FormattedPlural extends PureComponent {
-  static displayName = 'FormattedPlural';
+function FormattedPlural(props) {
+  const {
+    value,
+    other,
+    children,
+    intl: {formatPlural, textComponent: Text},
+  } = props;
 
-  static propTypes = {
-    ...pluralFormatPropTypes,
-    intl: intlShape,
-    value: PropTypes.any.isRequired,
+  let pluralCategory = formatPlural(value, props);
+  let formattedPlural = props[pluralCategory] || other;
 
-    other: PropTypes.node.isRequired,
-    zero: PropTypes.node,
-    one: PropTypes.node,
-    two: PropTypes.node,
-    few: PropTypes.node,
-    many: PropTypes.node,
-
-    children: PropTypes.func,
-  };
-
-  static defaultProps = {
-    type: 'cardinal',
-  };
-
-  constructor(props) {
-    super(props);
-    invariantIntlContext(props);
+  if (typeof children === 'function') {
+    return children(formattedPlural);
   }
 
-  render() {
-    const {formatPlural, textComponent: Text} = this.props.intl;
-    const {value, other, children} = this.props;
-
-    let pluralCategory = formatPlural(value, this.props);
-    let formattedPlural = this.props[pluralCategory] || other;
-
-    if (typeof children === 'function') {
-      return children(formattedPlural);
-    }
-
-    return <Text>{formattedPlural}</Text>;
-  }
+  return <Text>{formattedPlural}</Text>;
 }
+
+FormattedPlural.propTypes = {
+  ...pluralFormatPropTypes,
+  intl: intlShape,
+  value: PropTypes.any.isRequired,
+
+  other: PropTypes.node.isRequired,
+  zero: PropTypes.node,
+  one: PropTypes.node,
+  two: PropTypes.node,
+  few: PropTypes.node,
+  many: PropTypes.node,
+
+  children: PropTypes.func,
+};
+
+FormattedPlural.defaultProps = {
+  type: 'cardinal',
+};
+
+FormattedPlural.displayName = 'FormattedPlural';
 
 export default withIntl(FormattedPlural);

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -4,23 +4,18 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import React, {Component, Children} from 'react';
+import React, {PureComponent, Children} from 'react';
 import PropTypes from 'prop-types';
 import withIntl, {Provider} from './withIntl';
 import IntlMessageFormat from 'intl-messageformat';
 import IntlRelativeFormat from 'intl-relativeformat';
 import memoizeIntlConstructor from 'intl-format-cache';
 import invariant from 'invariant';
-import {
-  createError,
-  defaultErrorHandler,
-  shouldIntlComponentUpdate,
-  filterProps,
-  shallowEquals,
-} from '../utils';
+import {createError, defaultErrorHandler, filterProps} from '../utils';
 import {intlConfigPropTypes, intlFormatPropTypes} from '../types';
 import * as format from '../format';
 import areIntlLocalesSupported from 'intl-locales-supported';
+import shallowEquals from 'shallow-equal/objects';
 
 const intlConfigPropNames = Object.keys(intlConfigPropTypes);
 const intlFormatPropNames = Object.keys(intlFormatPropTypes);
@@ -86,7 +81,7 @@ function getBoundFormatFns(config, state) {
   }, {});
 }
 
-class IntlProvider extends Component {
+class IntlProvider extends PureComponent {
   static displayName = 'IntlProvider';
 
   static propTypes = {
@@ -175,10 +170,6 @@ class IntlProvider extends Component {
 
   getContext() {
     return this.state.context;
-  }
-
-  shouldComponentUpdate(...next) {
-    return shouldIntlComponentUpdate(this, ...next);
   }
 
   componentDidMount() {

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -82,8 +82,6 @@ function getBoundFormatFns(config, state) {
 }
 
 class IntlProvider extends PureComponent {
-  static displayName = 'IntlProvider';
-
   static propTypes = {
     ...intlConfigPropTypes,
     children: PropTypes.element.isRequired,

--- a/src/components/relative.js
+++ b/src/components/relative.js
@@ -66,8 +66,6 @@ function isSameDate(a, b) {
 }
 
 class FormattedRelative extends PureComponent {
-  static displayName = 'FormattedRelative';
-
   static propTypes = {
     ...relativeFormatPropTypes,
     intl: intlShape,

--- a/src/components/relative.js
+++ b/src/components/relative.js
@@ -4,11 +4,11 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import withIntl from './withIntl';
 import {intlShape, relativeFormatPropTypes} from '../types';
-import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
+import {invariantIntlContext} from '../utils';
 
 const SECOND = 1000;
 const MINUTE = 1000 * 60;
@@ -65,7 +65,7 @@ function isSameDate(a, b) {
   return isFinite(aTime) && isFinite(bTime) && aTime === bTime;
 }
 
-class FormattedRelative extends Component {
+class FormattedRelative extends PureComponent {
   static displayName = 'FormattedRelative';
 
   static propTypes = {
@@ -138,10 +138,6 @@ class FormattedRelative extends Component {
       return {now: intl.now(), prevValue: value};
     }
     return null;
-  }
-
-  shouldComponentUpdate(...next) {
-    return shouldIntlComponentUpdate(this, ...next);
   }
 
   componentDidUpdate() {

--- a/src/components/relative.js
+++ b/src/components/relative.js
@@ -8,7 +8,6 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import withIntl from './withIntl';
 import {intlShape, relativeFormatPropTypes} from '../types';
-import {invariantIntlContext} from '../utils';
 
 const SECOND = 1000;
 const MINUTE = 1000 * 60;
@@ -82,7 +81,6 @@ class FormattedRelative extends PureComponent {
 
   constructor(props) {
     super(props);
-    invariantIntlContext(props);
 
     let now = isFinite(props.initialNow)
       ? Number(props.initialNow)

--- a/src/components/time.js
+++ b/src/components/time.js
@@ -4,13 +4,13 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import withIntl from './withIntl';
 import {intlShape, dateTimeFormatPropTypes} from '../types';
-import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
+import {invariantIntlContext} from '../utils';
 
-class FormattedTime extends Component {
+class FormattedTime extends PureComponent {
   static displayName = 'FormattedTime';
 
   static propTypes = {
@@ -24,10 +24,6 @@ class FormattedTime extends Component {
   constructor(props) {
     super(props);
     invariantIntlContext(props);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shouldIntlComponentUpdate(this, nextProps, nextState);
   }
 
   render() {

--- a/src/components/time.js
+++ b/src/components/time.js
@@ -4,40 +4,35 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import React, {PureComponent} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import withIntl from './withIntl';
 import {intlShape, dateTimeFormatPropTypes} from '../types';
-import {invariantIntlContext} from '../utils';
 
-class FormattedTime extends PureComponent {
-  static displayName = 'FormattedTime';
+function FormattedTime(props) {
+  const {
+    value,
+    children,
+    intl: {formatTime, textComponent: Text},
+  } = props;
 
-  static propTypes = {
-    ...dateTimeFormatPropTypes,
-    intl: intlShape,
-    value: PropTypes.any.isRequired,
-    format: PropTypes.string,
-    children: PropTypes.func,
-  };
+  let formattedTime = formatTime(value, props);
 
-  constructor(props) {
-    super(props);
-    invariantIntlContext(props);
+  if (typeof children === 'function') {
+    return children(formattedTime);
   }
 
-  render() {
-    const {formatTime, textComponent: Text} = this.props.intl;
-    const {value, children} = this.props;
-
-    let formattedTime = formatTime(value, this.props);
-
-    if (typeof children === 'function') {
-      return children(formattedTime);
-    }
-
-    return <Text>{formattedTime}</Text>;
-  }
+  return <Text>{formattedTime}</Text>;
 }
+
+FormattedTime.propTypes = {
+  ...dateTimeFormatPropTypes,
+  intl: intlShape,
+  value: PropTypes.any.isRequired,
+  format: PropTypes.string,
+  children: PropTypes.func,
+};
+
+FormattedTime.displayName = 'FormattedTime';
 
 export default withIntl(FormattedTime);

--- a/src/components/withIntl.js
+++ b/src/components/withIntl.js
@@ -1,4 +1,4 @@
-import React, {Component, createContext} from 'react';
+import React, {createContext} from 'react';
 import {isValidElementType} from 'react-is';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import invariant from 'invariant';
@@ -39,32 +39,30 @@ function createWrapper(WrappedComponent) {
       "instead use the 'forwardRef' option and create a ref directly on the wrapped component."
   );
 
-  class WithIntl extends Component {
-    static displayName = `withIntl(${getDisplayName(WrappedComponent)})`;
-    static WrappedComponent = WrappedComponent;
+  function WithIntl(props) {
+    return (
+      <IntlConsumer>
+        {intl => {
+          if (enforceContext) {
+            invariantIntlContext({intl});
+          }
 
-    render() {
-      return (
-        <IntlConsumer>
-          {intl => {
-            if (enforceContext) {
-              invariantIntlContext({intl});
-            }
-
-            return (
-              <WrappedComponent
-                {...{
-                  ...this.props,
-                  [intlPropName]: intl,
-                }}
-                ref={forwardRef ? this.props.forwardedRef : null}
-              />
-            );
-          }}
-        </IntlConsumer>
-      );
-    }
+          return (
+            <WrappedComponent
+              {...{
+                ...props,
+                [intlPropName]: intl,
+              }}
+              ref={forwardRef ? props.forwardedRef : null}
+            />
+          );
+        }}
+      </IntlConsumer>
+    );
   }
+
+  WithIntl.displayName = `withIntl(${getDisplayName(WrappedComponent)})`;
+  WithIntl.WrappedComponent = WrappedComponent;
 
   if (forwardRef) {
     return hoistNonReactStatics(

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 /*
-HTML escaping and shallow-equals implementations are the same as React's
+HTML escaping is the same as React's
 (on purpose.) Therefore, it has the following Copyright and Licensing:
 
 Copyright 2013-2014, Facebook, Inc.
@@ -46,46 +46,6 @@ export function invariantIntlContext({intl} = {}) {
     '[React Intl] Could not find required `intl` object. ' +
       '<IntlProvider> needs to exist in the component ancestry.'
   );
-}
-
-export function shallowEquals(objA, objB) {
-  if (objA === objB) {
-    return true;
-  }
-
-  if (
-    typeof objA !== 'object' ||
-    objA === null ||
-    typeof objB !== 'object' ||
-    objB === null
-  ) {
-    return false;
-  }
-
-  let keysA = Object.keys(objA);
-  let keysB = Object.keys(objB);
-
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-
-  // Test for A's keys different from B.
-  let bHasOwnProperty = Object.prototype.hasOwnProperty.bind(objB);
-  for (let i = 0; i < keysA.length; i++) {
-    if (!bHasOwnProperty(keysA[i]) || objA[keysA[i]] !== objB[keysA[i]]) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-export function shouldIntlComponentUpdate(
-  {props, state},
-  nextProps,
-  nextState
-) {
-  return !shallowEquals(nextProps, props) || !shallowEquals(nextState, state);
 }
 
 export function createError(message, exception) {

--- a/test/unit/components/date.js
+++ b/test/unit/components/date.js
@@ -49,9 +49,12 @@ describe('<FormattedDate>', () => {
           <FormattedDate />,
           2
         );
-        expect(consoleError.calls.length).toBe(1);
+        expect(consoleError.calls.length).toBe(2);
         expect(consoleError.calls[0].arguments[0]).toContain(
-            '[React Intl] Error formatting date.\nRangeError'
+          'Warning: Failed prop type: The prop `value` is marked as required in `FormattedDate`, but its value is `undefined`.'
+        );
+        expect(consoleError.calls[1].arguments[0]).toContain(
+          '[React Intl] Error formatting date.\nRangeError'
         );
     });
 
@@ -67,26 +70,7 @@ describe('<FormattedDate>', () => {
         expect(rendered.type()).toBe('span');
         expect(rendered.text()).toBe(intl.formatDate(date));
     });
-
-    it('should not re-render when props and context are the same', () => {
-        const FormattedDate = mockContext(intl);
-        const date = Date.now();
-
-        const spy = createSpy().andReturn(null);
-        const withInlContext = mount(
-          <FormattedDate value={date}>
-            { spy }
-          </FormattedDate>
-        );
-
-        withInlContext.setProps({
-          ...withInlContext.props()
-        });
-        withInlContext.instance().mockContext(intl);
-
-        expect(spy.calls.length).toBe(1);
-    });
-
+    
     it('should re-render when props change', () => {
       const FormattedDate = mockContext(intl);
       const date = Date.now();

--- a/test/unit/components/number.js
+++ b/test/unit/components/number.js
@@ -59,24 +59,6 @@ describe('<FormattedNumber>', () => {
         expect(rendered.text()).toBe(intl.formatNumber(num));
     });
 
-    it('should not re-render when props and context are the same', () => {
-        const FormattedNumber = mockContext(intl);
-        const num = 1000;
-
-        const spy = createSpy().andReturn(null);
-        const withIntlContext = mount(
-          <FormattedNumber value={num}>
-            { spy }
-          </FormattedNumber>
-        );
-
-        withIntlContext.setProps({
-          ...withIntlContext.props()
-        });
-        withIntlContext.instance().mockContext(intl);
-
-        expect(spy.calls.length).toBe(1);
-    });
 
     it('should re-render when props change', () => {
       const FormattedNumber = mockContext(intl);

--- a/test/unit/components/plural.js
+++ b/test/unit/components/plural.js
@@ -82,23 +82,6 @@ describe('<FormattedPlural>', () => {
         );
     });
 
-    it('should not re-render when props and context are the same', () => {
-        const FormattedPlural = mockContext(intl);
-
-        const spy = createSpy().andReturn(null);
-        const withInlContext = mount(
-          <FormattedPlural value={1} one='foo' other='bar'>
-            { spy }
-          </FormattedPlural>
-        );
-
-        withInlContext.setProps({
-          ...withInlContext.props()
-        });
-        withInlContext.instance().mockContext(intl);
-
-        expect(spy.calls.length).toBe(1);
-    });
 
     it('should re-render when props change', () => {
         const FormattedPlural = mockContext(intl);

--- a/test/unit/components/provider.js
+++ b/test/unit/components/provider.js
@@ -69,7 +69,7 @@ describe('<IntlProvider>', () => {
     // If global.Intl is immutable, then skip this test.
     skipWhen(immutableIntl, (it) => {
         it('throws when `Intl` is missing from runtime', () => {
-            const IntlProvider = mockContext();
+            const IntlProvider = mockContext(null, false);
             global.Intl = undefined;
 
             expect(() => shallowDeep(<IntlProvider />, 2)).toThrow(
@@ -79,13 +79,13 @@ describe('<IntlProvider>', () => {
     });
 
     it('throws when no `children`', () => {
-        const IntlProvider = mockContext();
+        const IntlProvider = mockContext(null, false);
 
         expect(() => shallowDeep(<IntlProvider />, 2)).toThrow();
     });
 
     it('throws when more than one `children`', () => {
-        const IntlProvider = mockContext();
+        const IntlProvider = mockContext(null, false);
         const el = (
             <IntlProvider>
                 <Child />
@@ -97,7 +97,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('warns when no `locale` prop is provided', () => {
-        const IntlProvider = mockContext();
+        const IntlProvider = mockContext(null, false);
         const el = (
             <IntlProvider>
                 <Child />
@@ -112,7 +112,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('warns when `locale` prop provided has no locale data', () => {
-        const IntlProvider = mockContext();
+        const IntlProvider = mockContext(null, false);
         const el = (
             <IntlProvider locale="missing">
                 <Child />
@@ -129,7 +129,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('renders its `children`', () => {
-        const IntlProvider = mockContext();
+        const IntlProvider = mockContext(null, false);
         const el = (
             <IntlProvider locale="en">
                 <Child />
@@ -142,7 +142,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('provides `context.intl` with `intlShape` props', () => {
-        const IntlProvider = mockContext();
+        const IntlProvider = mockContext(null, false);
         const el = (
             <IntlProvider locale="en">
                 <Child />
@@ -157,7 +157,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('provides `context.intl` with values from intl config props', () => {
-        const IntlProvider = mockContext();
+        const IntlProvider = mockContext(null, false);
         const props = {
             locale       : 'fr-FR',
             timeZone     : 'UTC',
@@ -185,7 +185,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('provides `context.intl` with timeZone from intl config props when it is specified', () => {
-        const IntlProvider = mockContext();
+        const IntlProvider = mockContext(null, false);
         const props = {
             timeZone: 'Europe/Paris',
         };
@@ -202,7 +202,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('provides `context.intl` with values from `defaultProps` for missing or undefined props', () => {
-        const IntlProvider = mockContext();
+        const IntlProvider = mockContext(null, false);
         const props = {
             locale: 'en-US',
             defaultLocale: undefined,
@@ -223,7 +223,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('provides `context.intl` with format methods bound to intl config props', () => {
-        const IntlProvider = mockContext();
+        const IntlProvider = mockContext(null, false);
         const el = (
             <IntlProvider
                 locale="en"
@@ -253,7 +253,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('inherits from an <IntlProvider> ancestor', () => {
-        let IntlProvider = mockContext();
+        let IntlProvider = mockContext(null, false);
         const props = {
             locale  : 'en',
             timeZone: 'UTC',
@@ -304,7 +304,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('shadows inherited intl config props from an <IntlProvider> ancestor', () => {
-        let IntlProvider = mockContext()
+        let IntlProvider = mockContext(null, false)
         const props = {
             locale  : 'en',
             timeZone  : 'Australia/Adelaide',
@@ -360,7 +360,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('should not re-render when props and context are the same', () => {
-        let IntlProvider = mockContext()
+        let IntlProvider = mockContext(null, false)
         const parentContext = getIntlContext(
           <IntlProvider locale='en'>
             <Child />
@@ -383,7 +383,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('should re-render when props change', () => {
-        let IntlProvider = mockContext()
+        let IntlProvider = mockContext(null, false)
         const parentContext = getIntlContext(
           <IntlProvider locale='en'>
             <Child />
@@ -407,7 +407,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('should re-render when context changes', () => {
-        let IntlProvider = mockContext()
+        let IntlProvider = mockContext(null, false)
         const initialParentContext = getIntlContext(
           <IntlProvider locale='en'>
             <Child />
@@ -436,7 +436,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('accepts `initialNow` prop', () => {
-        const IntlProvider = mockContext();
+        const IntlProvider = mockContext(null, false);
         const initialNow = 1234;
 
         // doing this to get the actual "now" at render time
@@ -461,7 +461,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('defaults `initialNow` to `Date.now()`', () => {
-        const IntlProvider = mockContext();
+        const IntlProvider = mockContext(null, false);
         const Child = ({ intl }) => ( // see above
           <div>
             { intl.now() }
@@ -504,7 +504,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('updates `now()` to return the current date when mounted', () => {
-        const IntlProvider = mockContext();
+        const IntlProvider = mockContext(null, false);
         const initialNow = 1234;
 
         const intl = getIntlContext(

--- a/test/unit/components/time.js
+++ b/test/unit/components/time.js
@@ -46,8 +46,11 @@ describe('<FormattedTime>', () => {
           ...withIntlContext.props(),
           value: undefined
         });
-        expect(consoleError.calls.length).toBe(1);
+        expect(consoleError.calls.length).toBe(2);
         expect(consoleError.calls[0].arguments[0]).toContain(
+          'Warning: Failed prop type: The prop `value` is marked as required in `FormattedTime`, but its value is `undefined`.'
+      );
+        expect(consoleError.calls[1].arguments[0]).toContain(
             '[React Intl] Error formatting time.\nRangeError'
         );
     });
@@ -63,25 +66,6 @@ describe('<FormattedTime>', () => {
 
         expect(rendered.type()).toBe('span');
         expect(rendered.text()).toBe(intl.formatTime(date));
-    });
-
-    it('should not re-render when props and context are the same', () => {
-        const FormattedTime = mockContext(intl);
-        const date = Date.now();
-
-        const spy = createSpy().andReturn(null);
-        const withIntlContext = mount(
-          <FormattedTime value={date}>
-            { spy }
-          </FormattedTime>
-        );
-
-        withIntlContext.setProps({
-          ...withIntlContext.props()
-        });
-        withIntlContext.instance().mockContext(intl);
-
-        expect(spy.calls.length).toBe(1);
     });
 
     it('should re-render when props change', () => {

--- a/test/unit/testUtils.js
+++ b/test/unit/testUtils.js
@@ -1,13 +1,14 @@
 import React from 'react'
 import {shallow} from 'enzyme';
+import { invariantIntlContext } from '../../src/utils';
 
-export const makeMockContext = (modulePath, exportName = 'default') => (intl = null) => {
+export const makeMockContext = (modulePath, exportName = 'default') => (intl = null, enforceContext = true) => {
   jest.resetModules();
   jest.doMock(
     '../../src/components/withIntl',
     () => ({
       __esModule: true,
-      default: (WrappedComponent) => {
+      default: (WrappedComponent, opts = {}) => {
         return class extends React.Component {
           constructor (props) {
             super(props)
@@ -22,6 +23,11 @@ export const makeMockContext = (modulePath, exportName = 'default') => (intl = n
           }
 
           render () {
+            const _enforceContext = opts.enforceContext !== undefined ? opts.enforceContext : enforceContext
+            // Represents withIntl more accurately
+            if (_enforceContext) {
+              invariantIntlContext({intl: this.state.intl || intl})
+            }
             return (
               <WrappedComponent
                 {...this.props}
@@ -71,7 +77,7 @@ export class SpyComponent extends React.Component {
 
 const mockProviderContext = makeMockContext('../../src/components/provider');
 export const generateIntlContext = (intl) => {
-  const IntlProvider = mockProviderContext();
+  const IntlProvider = mockProviderContext(null, false);
 
   return shallowDeep(
     <IntlProvider {...intl}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6539,6 +6539,11 @@ sha.js@^2.4.0, sha.js@^2.4.8, sha.js@~2.4.4:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+shallow-equal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.1.0.tgz#cc022f030dcba0d1c198abf658a3c6c744e171ca"
+  integrity sha512-0SW1nWo1hnabO62SEeHsl8nmTVVEzguVWZCj5gaQrgWAxz/BaCja4OWdJBWLVPDxdtE/WU7c98uUCCXyPHSCvw==
+
 shasum@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/shasum/-/shasum-1.0.2.tgz#e7012310d8f417f4deb5712150e5678b87ae565f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,21 +1851,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-cldr-core@^34.0.0:
-  version "34.0.0"
-  resolved "https://registry.yarnpkg.com/cldr-core/-/cldr-core-34.0.0.tgz#2e9d1f9909868e93e70c4813a74f331af028d66c"
-  integrity sha512-PFHHn2SlqRdqD1ZC8Ddw5ZOSwJdqsmTY6fnOVsX5iMfOShqXs7QhpkIo4eOvz7rFdEivp/IrMDPs47Z4z1rD3g==
-
-cldr-dates-full@^34.0.0:
-  version "34.0.0"
-  resolved "https://registry.yarnpkg.com/cldr-dates-full/-/cldr-dates-full-34.0.0.tgz#e2f9c254ab7d6b0a5d28481737138530eebb3be6"
-  integrity sha512-mKGQF16YAEeMOlTA1oT8vWOnm2VuCE1yGQQN7CbnKirVhXigoa0uUiOwjajCZSVpLMyTwWi8AvlY1pjNlX6uRw==
-
-cldr-numbers-full@^34.0.0:
-  version "34.0.0"
-  resolved "https://registry.yarnpkg.com/cldr-numbers-full/-/cldr-numbers-full-34.0.0.tgz#f9e62bd4dda1fb4e17c7a3e4b170da2263f43dac"
-  integrity sha512-+Bqxnym5Fv81u/iBoZvy2dUfPQdAc4KbX4QDptq9PLx846iQkRN0UKo3t5xZu97rUlRw2fFGaRt+KO6iMPo+RA==
-
 cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -3153,19 +3138,6 @@ form-data@^2.3.1, form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
-
-formatjs-extract-cldr-data@^6.0.0:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/formatjs-extract-cldr-data/-/formatjs-extract-cldr-data-6.1.3.tgz#5b8a7570a44fcbe3b5ee3b6bb9c004d4a29005a5"
-  integrity sha512-EeQ+koMgGtuBpiF0emlP8lKjcforMjhEC/FWSTJBwX0sRpS4AIBYvUbQqfkh4qTD2awjmCnxrATGb3npK53sAA==
-  dependencies:
-    cldr-core "^34.0.0"
-    cldr-dates-full "^34.0.0"
-    cldr-numbers-full "^34.0.0"
-    glob "^7.0.0"
-    make-plural "^4.0.0"
-    object.assign "^4.0.3"
-    uglify-js "^3.0.0"
 
 formidable@^1.2.0:
   version "1.2.1"
@@ -4784,7 +4756,7 @@ make-dir@^2.0.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-plural@^4.0.0, make-plural@^4.3.0:
+make-plural@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-4.3.0.tgz#f23de08efdb0cac2e0c9ba9f315b0dff6b4c2735"
   integrity sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==
@@ -5299,7 +5271,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.0.3, object.assign@^4.1.0:
+object.assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
   integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
@@ -5922,11 +5894,6 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-display-name@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.4.tgz#e2a670b81d79a2204335510c01246f4c92ff12cf"
-  integrity sha512-zvU6iouW+SWwHTyThwxGICjJYCMZFk/6r/+jmOdC7ntQoPlS/Pqb81MkxaMf2bHTSq9TN3K3zX2/ayMW/jCtyA==
 
 react-dom@^16.8.6:
   version "16.8.6"
@@ -7175,7 +7142,7 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-uglify-js@^3.0.0, uglify-js@^3.1.4, uglify-js@^3.4.9:
+uglify-js@^3.1.4, uglify-js@^3.4.9:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
   integrity sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==


### PR DESCRIPTION
- Use shallow-equal instead of custom impl
- Convert stateless components to stateless functional components. We already cache Formatters so re-rendering is super cheap.
- remove unused packages
- no need to enforce intl bc withIntl already does that