### PR TITLE
bug: fix document link typo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,6 @@ All guides are listed below:
 - [Getting Started](./Getting-Started.md)
 - [Components](./Components.md)
 - [API](./API.md)
-- [Testing with `react-intl`](./Testing-with-React-intl.md)
+- [Testing with `react-intl`](./Testing-with-React-Intl.md)
 - [IDE Plugins](./IDE-plugins-&-Tools.md)
 - [Upgrade Guide](./Upgrade-Guide.md)


### PR DESCRIPTION
so it correctly links to https://github.com/formatjs/react-intl/blob/master/docs/Testing-with-React-Intl.md