### PR TITLE
chore: enhance types

### DIFF
--- a/src/components/message.tsx
+++ b/src/components/message.tsx
@@ -12,7 +12,7 @@ import {MessageDescriptor, IntlShape} from '../types';
 import * as shallowEquals_ from 'shallow-equal/objects';
 const shallowEquals = shallowEquals_;
 import {formatMessage as baseFormatMessage} from '../format';
-import {invariantIntlContext} from '../utils';
+import {invariantIntlContext, DEFAULT_INTL_CONFIG} from '../utils';
 
 const defaultFormatMessage: IntlShape['formatMessage'] = (
   descriptor,
@@ -25,7 +25,10 @@ const defaultFormatMessage: IntlShape['formatMessage'] = (
   }
 
   return baseFormatMessage(
-    {defaultLocale: 'en'},
+    {
+      ...DEFAULT_INTL_CONFIG,
+      locale: 'en',
+    },
     {getMessageFormat: memoizeIntlConstructor(IntlMessageFormat)},
     descriptor,
     values

--- a/src/components/provider.tsx
+++ b/src/components/provider.tsx
@@ -15,7 +15,7 @@ import * as invariant_ from 'invariant';
 // does not export a default
 // https://github.com/rollup/rollup/issues/1267
 const invariant = invariant_;
-import {createError, defaultErrorHandler, filterProps} from '../utils';
+import {createError, filterProps, DEFAULT_INTL_CONFIG} from '../utils';
 import {IntlConfig, IntlShape, IntlFormatters} from '../types';
 import {formatters} from '../format';
 import areIntlLocalesSupported from 'intl-locales-supported';
@@ -44,29 +44,19 @@ const intlFormatPropNames: Array<keyof IntlFormatters> = [
   'formatHTMLMessage',
 ];
 
-// These are not a static property on the `IntlProvider` class so the intl
-// config values can be inherited from an <IntlProvider> ancestor.
-const defaultProps = {
-  formats: {},
-  messages: {},
-  timeZone: undefined,
-  textComponent: 'span',
-
-  defaultLocale: 'en',
-  defaultFormats: {},
-
-  onError: defaultErrorHandler,
-};
-
-function getConfig(filteredProps: IntlConfig): IntlConfig {
-  let config = {...filteredProps};
+function getConfig(filteredProps: OptionalIntlConfig): IntlConfig {
+  let config: IntlConfig = {
+    ...DEFAULT_INTL_CONFIG,
+    ...filteredProps,
+  };
 
   // Apply default props. This must be applied last after the props have
   // been resolved and inherited from any <IntlProvider> in the ancestry.
   // This matches how React resolves `defaultProps`.
-  for (const propName in defaultProps) {
+  for (const propName in DEFAULT_INTL_CONFIG) {
     if (config[propName as 'timeZone'] === undefined) {
-      config[propName as 'timeZone'] = defaultProps[propName as 'timeZone'];
+      config[propName as 'timeZone'] =
+        DEFAULT_INTL_CONFIG[propName as 'timeZone'];
     }
   }
 
@@ -89,7 +79,7 @@ function getConfig(filteredProps: IntlConfig): IntlConfig {
       ...config,
       locale: defaultLocale,
       formats: defaultFormats,
-      messages: defaultProps.messages,
+      messages: DEFAULT_INTL_CONFIG.messages,
     };
   }
 
@@ -112,19 +102,26 @@ function getBoundFormatFns(config: IntlConfig, state: State) {
   ) as IntlFormatters;
 }
 
-interface Props extends IntlConfig, WrappedComponentProps {
+interface InternalProps {
   children: React.ElementType<any>;
   initialNow?: number;
 }
+
+type Props = IntlConfig & WrappedComponentProps & InternalProps;
 
 interface State {
   context: IntlShape;
   filteredProps?: IntlConfig;
 }
 
-class IntlProvider extends React.PureComponent<Props, State> {
+type OptionalIntlConfig = Omit<IntlConfig, keyof typeof DEFAULT_INTL_CONFIG> &
+  Partial<typeof DEFAULT_INTL_CONFIG>;
+
+type ResolvedProps = WrappedComponentProps & InternalProps & OptionalIntlConfig;
+
+class IntlProvider extends React.PureComponent<ResolvedProps, State> {
   private _didDisplay?: boolean;
-  constructor(props: Props) {
+  constructor(props: ResolvedProps) {
     super(props);
 
     invariant(
@@ -175,7 +172,7 @@ class IntlProvider extends React.PureComponent<Props, State> {
     };
   }
 
-  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+  static getDerivedStateFromProps(nextProps: ResolvedProps, prevState: State) {
     const {intl: intlContext} = nextProps;
 
     // Build a whitelisted config object from `props`, defaults, and

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,18 +9,18 @@ import IntlMessageFormat from 'intl-messageformat';
 import IntlRelativeFormat from 'intl-relativeformat';
 
 export interface IntlConfig {
-  locale?: string;
+  locale: string;
   timeZone?: string;
-  formats?: CustomFormats;
-  textComponent?: any;
-  messages?: Record<string, string>;
+  formats: CustomFormats;
+  textComponent: React.ComponentType | keyof React.ReactHTML;
+  messages: Record<string, string>;
   defaultLocale: string;
-  defaultFormats?: CustomFormats;
-  onError?(err: string): void;
+  defaultFormats: CustomFormats;
+  onError(err: string): void;
 }
 
-export interface CustomFormats extends Formats {
-  relative: Record<string, IntlRelativeFormatOptions>;
+export interface CustomFormats extends Partial<Formats> {
+  relative?: Record<string, IntlRelativeFormatOptions>;
 }
 
 export interface CustomFormatConfig {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ file in the root directory of React's source tree.
 */
 
 import * as invariant_ from 'invariant';
+import {IntlConfig} from './types';
 // Since rollup cannot deal with namespace being a function,
 // this is to interop with TypeScript since `invariant`
 // does not export a default
@@ -70,3 +71,26 @@ export function defaultErrorHandler(error: string) {
     console.error(error);
   }
 }
+
+// These are not a static property on the `IntlProvider` class so the intl
+// config values can be inherited from an <IntlProvider> ancestor.
+export const DEFAULT_INTL_CONFIG: Pick<
+  IntlConfig,
+  | 'formats'
+  | 'messages'
+  | 'timeZone'
+  | 'textComponent'
+  | 'defaultLocale'
+  | 'defaultFormats'
+  | 'onError'
+> = {
+  formats: {},
+  messages: {},
+  timeZone: undefined,
+  textComponent: 'span',
+
+  defaultLocale: 'en',
+  defaultFormats: {},
+
+  onError: defaultErrorHandler,
+};


### PR DESCRIPTION
- make WrappedComponentProps take in generic so we can strongly type `IntlPropName`
- work around the fact that IntlProvider cannot have defaultProps