### PR TITLE
fix(deps): move formatjs/intl-relativetimeformat to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "setupTestFrameworkScriptFile": "./test/setup.js"
   },
   "dependencies": {
+    "@formatjs/intl-relativetimeformat": "^2.3.1",
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/invariant": "^2.2.30",
     "@types/react": "^16.8.20",
@@ -83,7 +84,6 @@
     "@babel/plugin-transform-modules-commonjs": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
-    "@formatjs/intl-relativetimeformat": "^2.3.1",
     "@types/benchmark": "^1.0.31",
     "@types/enzyme": "^3.10.1",
     "@types/jest": "^24.0.13",


### PR DESCRIPTION
it was in devDependencies, but is actually a production dependency