### PR TITLE
Change type to allow autocompletion and existence checking

### DIFF
--- a/src/define-messages.ts
+++ b/src/define-messages.ts
@@ -6,7 +6,9 @@ import {MessageDescriptor} from './types';
  * See the accompanying LICENSE file for terms.
  */
 
-type Messages<Names extends keyof any = string> = { [key in Names]: MessageDescriptor }
+type Messages<Names extends keyof any = string> = {
+  [key in Names]: MessageDescriptor;
+};
 
 export default function defineMessages<Names extends keyof any>(
   messageDescriptors: Messages<Names>

--- a/src/define-messages.ts
+++ b/src/define-messages.ts
@@ -6,8 +6,10 @@ import {MessageDescriptor} from './types';
  * See the accompanying LICENSE file for terms.
  */
 
-export default function defineMessages(
-  messageDescriptors: Record<string, MessageDescriptor>
+type Messages<Names extends keyof any = string> = { [key in Names]: MessageDescriptor }
+
+export default function defineMessages<Names extends keyof any>(
+  messageDescriptors: Messages<Names>
 ) {
   // This simply returns what's passed-in because it's meant to be a hook for
   // babel-plugin-react-intl.


### PR DESCRIPTION
The current types don't help the user with using defined messages.

The old DefinitelyTyped types supported this much better.

I'l updated the types in this project based on the DefinitelyTypes ones at https://github.com/DefinitelyTyped/DefinitelyTyped/blob/696809615107a57fc0b2c4d8efacf60622486655/types/react-intl/index.d.ts#L44

With this change, you can autocomplete defined translations as well as receive a type error when you attempt to use a message this is not defined.