### PR TITLE
[Typescript] Add "types" property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "main": "./dist/index.js",
   "module": "./lib/index.js",
+  "types": "./dist/index.d.ts",
   "browserify-shim": {
     "react": "global:React"
   },


### PR DESCRIPTION
I just upgraded `react-intl` to the latest newest version and looks like the types are not being exported. This PR fixes it.

PD: Looks like some of the "classic" types are not available on this new version (e.g `InjectedIntlProps` / `InjectIntl`), it might be a good idea to add which ones should be used instead in the upgrade guide.