### PR TITLE
docs: fix documented type for `IntlConfig`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -166,14 +166,14 @@ export default injectIntl(ClassComponent);
 
 ```ts
 interface IntlConfig {
-  locale?: string;
+  locale: string;
   timeZone?: string;
-  formats?: CustomFormats;
-  textComponent?: any;
-  messages?: Record<string, string>;
+  formats: CustomFormats;
+  textComponent?: React.ComponentType | keyof React.ReactHTML;
+  messages: Record<string, string> | Record<string, MessageFormatElement[]>;
   defaultLocale: string;
-  defaultFormats?: CustomFormats;
-  onError?(err: string): void;
+  defaultFormats: CustomFormats;
+  onError(err: string): void;
 }
 
 interface IntlFormatters {

--- a/docs/Components.md
+++ b/docs/Components.md
@@ -51,8 +51,8 @@ interface IntlConfig {
   locale: string;
   timeZone?: string;
   formats: CustomFormats;
-  textComponent: React.ComponentType | keyof React.ReactHTML;
-  messages: Record<string, string>;
+  textComponent?: React.ComponentType | keyof React.ReactHTML;
+  messages: Record<string, string> | Record<string, MessageFormatElement[]>;
   defaultLocale: string;
   defaultFormats: CustomFormats;
   onError(err: string): void;


### PR DESCRIPTION
these did not match the definition in `types.ts` -- https://github.com/formatjs/react-intl/blob/master/src/types.ts#L17

I think it's important that the docs reflects the updated typing for `messages` -- caught me by surprise. 