### PR TITLE
feat: extend numberformat to unified

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -347,6 +347,24 @@ formatNumber(0.5, {style: 'percent'}); // "50%"
 formatNumber(1000, {style: 'currency', currency: 'USD'}); // $1,000
 ```
 
+**Formatting Number using `unit`**
+
+Currently this is part of [Unified NumberFormat](https://github.com/tc39/proposal-unified-intl-numberformat) which is stage 3. We've provided a polyfill [here](https://github.com/formatjs/formatjs/tree/master/packages/intl-unified-numberformat) and `react-intl` types allow users to pass in a [sanctioned unit](https://github.com/formatjs/formatjs/tree/master/packages/intl-unified-numberformat):
+
+```js
+formatNumber(1000, {
+  style: 'unit',
+  unit: 'kilobyte',
+  unitDisplay: 'narrow',
+}); // "1,000kB"
+
+formatNumber(1000, {
+  unit: 'fahrenheit',
+  unitDisplay: 'long',
+  style: 'unit',
+}); // "1,000 degrees Fahrenheit"
+```
+
 #### `formatPlural`
 
 ```ts

--- a/docs/Components.md
+++ b/docs/Components.md
@@ -390,6 +390,36 @@ By default `<FormattedNumber>` will render the formatted number into a `<span>`.
 <span>1,000</span>
 ```
 
+**Formatting Number using `unit`**
+
+Currently this is part of [Unified NumberFormat](https://github.com/tc39/proposal-unified-intl-numberformat) which is stage 3. We've provided a polyfill [here](https://github.com/formatjs/formatjs/tree/master/packages/intl-unified-numberformat) and `react-intl` types allow users to pass in a [sanctioned unit](https://github.com/formatjs/formatjs/tree/master/packages/intl-unified-numberformat). For example:
+
+```tsx
+<FormattedNumber
+  value={1000}
+  style="unit"
+  unit="kilobyte"
+  unitDisplay="narrow"
+/>
+```
+
+```html
+<span>1,000kB</span>
+```
+
+```tsx
+<FormattedNumber
+  value={1000}
+  unit="fahrenheit"
+  unitDisplay="long"
+  style="unit"
+/>
+```
+
+```html
+<span>1,000 degrees Fahrenheit</span>
+```
+
 ### `FormattedNumberParts`
 
 This component provides more customization to `FormattedNumber` by allowing children function to have access to underlying parts of the formatted date. The available parts are listed [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/formatToParts)

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -16,6 +16,7 @@
     - [React Native](#react-native)
       - [React Native on iOS](#react-native-on-ios)
       - [DOMParser](#domparser-1)
+  - [Stage-3 Intl Features](#stage-3-intl-features)
   - [Creating an I18n Context](#creating-an-i18n-context)
   - [Formatting Data](#formatting-data)
 - [Core Concepts](#core-concepts)
@@ -158,6 +159,12 @@ If you cannot use the Intl variant of JSC (e.g on iOS), follow the instructions 
 #### DOMParser
 
 We also rely on `DOMParser` to format rich text, thus for JSC will need to polyfill using [xmldom](https://github.com/jindw/xmldom).
+
+## Stage-3 Intl Features
+
+FormatJS also provides types & polyfill for the following Stage 3 Intl APIs:
+
+- Unified NumberFormat: [polyfill](https://www.npmjs.com/package/@formatjs/intl-unified-numberformat) & [spec](https://github.com/tc39/proposal-unified-intl-numberformat)
 
 ## Creating an I18n Context
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1267,6 +1267,14 @@
         "@formatjs/intl-utils": "^0.6.1"
       }
     },
+    "@formatjs/intl-unified-numberformat": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-0.4.5.tgz",
+      "integrity": "sha512-H1bA7q3PHiDxoSbkD5KC42mNWogst8dFkUaWCpcb7LMeS6+uJh9JlNzzlF91ZXBhwxE5EyWZRPZVXVE7UoA7AA==",
+      "requires": {
+        "@formatjs/intl-utils": "^0.6.1"
+      }
+    },
     "@formatjs/intl-utils": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@formatjs/intl-relativetimeformat": "^2.8.2",
+    "@formatjs/intl-unified-numberformat": "^0.4.5",
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/invariant": "^2.2.30",
     "hoist-non-react-statics": "^3.3.0",

--- a/src/formatters/number.ts
+++ b/src/formatters/number.ts
@@ -1,12 +1,15 @@
 import {IntlConfig, Formatters, IntlFormatters} from '../types';
 import {getNamedFormat, filterProps, createError} from '../utils';
+import {UnifiedNumberFormatOptions} from '@formatjs/intl-unified-numberformat';
 
-const NUMBER_FORMAT_OPTIONS: Array<keyof Intl.NumberFormatOptions> = [
+const NUMBER_FORMAT_OPTIONS: Array<keyof UnifiedNumberFormatOptions> = [
   'localeMatcher',
 
   'style',
   'currency',
   'currencyDisplay',
+  'unit',
+  'unitDisplay',
   'useGrouping',
 
   'minimumIntegerDigits',

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ import IntlRelativeTimeFormat, {
   IntlRelativeTimeFormatOptions,
 } from '@formatjs/intl-relativetimeformat';
 import {MessageFormatElement} from 'intl-messageformat-parser';
+import {UnifiedNumberFormatOptions} from '@formatjs/intl-unified-numberformat';
 
 export interface IntlConfig {
   locale: string;
@@ -39,7 +40,7 @@ export type FormatDateOptions = Exclude<
 > &
   CustomFormatConfig;
 export type FormatNumberOptions = Exclude<
-  Intl.NumberFormatOptions,
+  UnifiedNumberFormatOptions,
   'localeMatcher'
 > &
   CustomFormatConfig;


### PR DESCRIPTION
Add documentation, extend types. Part of #1463
Currently this is part of [Unified NumberFormat](https://github.com/tc39/proposal-unified-intl-numberformat) which is stage 3. We've provided a polyfill [here](https://github.com/formatjs/formatjs/tree/master/packages/intl-unified-numberformat) and `react-intl` types allow users to pass in a [sanctioned unit](https://github.com/formatjs/formatjs/tree/master/packages/intl-unified-numberformat). For example:

```tsx
<FormattedNumber
  value={1000}
  style="unit"
  unit="kilobyte"
  unitDisplay="narrow"
/>
```

```html
<span>1,000kB</span>
```

```tsx
<FormattedNumber
  value={1000}
  unit="fahrenheit"
  unitDisplay="long"
  style="unit"
/>
```

```html
<span>1,000 degrees Fahrenheit</span>
```