### PR TITLE
Mention types change in the upgrade guide

### DIFF
--- a/docs/Upgrade-Guide-2.x.md
+++ b/docs/Upgrade-Guide-2.x.md
@@ -16,7 +16,6 @@
 - [Update How Relative Times are Formatted](#update-how-relative-times-are-formatted)
   - [Rename `FormattedRelative`'s `now` Prop to `initialNow`](#rename-formattedrelatives-now-prop-to-initialnow)
   - [Merge `formatRelative()`'s Second and Third Arguments](#merge-formatrelatives-second-and-third-arguments)
-- [Update Types](#update-types)
 
 <!-- tocstop -->
 
@@ -266,7 +265,3 @@ let relative = this.props.intl.formatRelative(date, {
 ```
 
 **Note:** In React Intl v2, the [`formatRelative()`](API.md#formatrelative) function is injected via [`injectIntl()`](API.md#injectintl).
-
-## Update Types
-
-react-intl now comes with Typescript types out of the box. Note that you may need to change your code if you were relying on the now deprecated **@types/react-intl**. For example, **@types/react-intl** used to export a `InjectedIntlProps` that is we decided to name `WrappedComponentProps`.

--- a/docs/Upgrade-Guide-2.x.md
+++ b/docs/Upgrade-Guide-2.x.md
@@ -16,6 +16,7 @@
 - [Update How Relative Times are Formatted](#update-how-relative-times-are-formatted)
   - [Rename `FormattedRelative`'s `now` Prop to `initialNow`](#rename-formattedrelatives-now-prop-to-initialnow)
   - [Merge `formatRelative()`'s Second and Third Arguments](#merge-formatrelatives-second-and-third-arguments)
+- [Update Types](#update-types)
 
 <!-- tocstop -->
 
@@ -265,3 +266,7 @@ let relative = this.props.intl.formatRelative(date, {
 ```
 
 **Note:** In React Intl v2, the [`formatRelative()`](API.md#formatrelative) function is injected via [`injectIntl()`](API.md#injectintl).
+
+## Update Types
+
+react-intl now comes with Typescript types out of the box. Note that you may need to change your code if you were relying on the now deprecated **@types/react-intl**. For example, **@types/react-intl** used to export a `InjectedIntlProps` that is we decided to name `WrappedComponentProps`.

--- a/docs/Upgrade-Guide.md
+++ b/docs/Upgrade-Guide.md
@@ -184,6 +184,8 @@ import {IntlShape} from 'react-intl/lib/types'; // Incorrect
 
 If we're missing any interface top level support, please let us know and/or submitting a PR is greatly appreciated :)
 
+Note that you might need to make a few changes to your code if you were relying on the now deprecated **@types/react-intl** package. The most common example is `InjectedIntlProps` which must be replaced with `WrappedComponentProps`.
+
 ## FormattedRelativeTime
 
 When we introduced `FormattedRelative`, the spec for [`Intl.RelativeTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat) was still unstable. It has now reached stage 3 and multiple browsers have implemented it. However, its API is different from `FormattedRelative` so we've adjusted its API to match the spec which means it's not backwards compatible.


### PR DESCRIPTION
Although not a breaking change and outside of react-intl's reach, it'd be nice to inform developers about the new types. This PR adds a note about it. I'm not going into too much details as I understand that it's not the role of react-intl but just mention it.

Closes #1515 
