### PR TITLE
chore: fix typo in example

### DIFF
--- a/examples/Advanced.tsx
+++ b/examples/Advanced.tsx
@@ -29,7 +29,7 @@ const messageAst = Object.keys(messages).reduce(
   {}
 );
 
-const intl = createIntl({locale: 'de', messages: messageAst});
+const intl = createIntl({locale: 'en', messages: messageAst});
 
 const App: React.FC<Props> = () => {
   return (


### PR DESCRIPTION
i have come across this typo while reading the examples. createIntl creates a new Intl object and gives it a locale-value of "de", but the messages are actually written in english.