### PR TITLE
chore: Update docs name for `formatList` function signature

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -405,7 +405,7 @@ type ListFormatOptions = {
   style?: 'long' | 'short' | 'narrow';
 };
 
-function formatPlural(
+function formatList(
   elements: (string | React.ReactNode)[],
   options?: Intl.ListFormatOptions
 ): string | React.ReactNode[];


### PR DESCRIPTION
Hoping to get a treasured contributor mention for this dramatic change! 

I don't think there's any clarification I can add here, this looks just like something missed when copy-pasting doc formatting. If I can add anything, please let me know.