### PR TITLE
chore: add an example (formatjs#1441)

### DIFF
--- a/examples/HandleChange.tsx
+++ b/examples/HandleChange.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import {createIntl, createIntlCache, RawIntlProvider} from '../';
+
+const messages: Record<string, object> = {
+  'en-US': {selectalanguage: 'Select a language'},
+  'pt-BR': {selectalanguage: 'Selecione uma linguagem'},
+};
+
+const initialLocale = 'en-US';
+export const cache = createIntlCache();
+/** You can use this variable in other files even after reassigning it. */
+export let intl = createIntl(
+  {locale: initialLocale, messages: messages[initialLocale]},
+  cache
+);
+export let fmt = intl.formatMessage;
+
+const App: React.FC = () => {
+  // You could use redux to get the locale or get it from the url.
+  const [locale, setLocale] = React.useState(initialLocale);
+
+  const changeLanguage = (newLocale: string) => {
+    intl = createIntl(
+      {locale: newLocale, messages: messages[newLocale]},
+      cache
+    );
+    fmt = intl.formatMessage;
+    document.documentElement.lang = newLocale;
+    setLocale(newLocale);
+  };
+
+  return (
+    <RawIntlProvider value={intl}>
+      <h1>{fmt({id: 'selectalanguage'})}</h1>
+      <select
+        name="locale"
+        defaultValue={locale}
+        id="locale"
+        onChange={event => changeLanguage(event.target.value)}
+      >
+        {Object.keys(messages).map(locale => (
+          <option value={locale}>{locale}</option>
+        ))}
+      </select>
+    </RawIntlProvider>
+  );
+};
+
+export default App;

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,6 +11,7 @@
     	<div id="hooks"></div>
         <div id="advanced"></div>
         <div id="injected"></div>
+        <div id="handlechange"></div>
         <script src="./index.tsx"></script>
     </body>
 </html>

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -7,6 +7,7 @@ import Messages from './Messages';
 import Hooks from './Hooks';
 import Advanced from './Advanced';
 import Injected from './Injected';
+import HandleChange from './HandleChange';
 
 ReactDOM.render(<Timezone />, document.getElementById('timezone'));
 
@@ -15,3 +16,4 @@ ReactDOM.render(<Hooks />, document.getElementById('hooks'));
 
 ReactDOM.render(<Advanced />, document.getElementById('advanced'));
 ReactDOM.render(<Injected />, document.getElementById('injected'));
+ReactDOM.render(<HandleChange />, document.getElementById('handlechange'));


### PR DESCRIPTION
This example shows how to change the language and the messages when using the createIntl() function. It also allows to use intl object in other files even after a language change.

As I spent hours and hours discovering how to properly change intl.locale and intl.message, I'm submitting this.